### PR TITLE
 Makes editing of build properties possible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ resources/fonts
 resources/scripts/app.all.js
 resources/scripts/app.min.js
 /templates
+# local properties
+**/local.build.properties
 # IDE
 .idea
 .DS_Store

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 #Thu, 08 Oct 2015 16:32:08 +0200
 
 # path to executables
-npm=npm
-gulp=gulp
+npm=/usr/local/bin/npm
+gulp=/usr/local/bin/gulp
 node.PATH=/usr/local/bin

--- a/build.properties
+++ b/build.properties
@@ -1,6 +1,6 @@
 #Thu, 08 Oct 2015 16:32:08 +0200
 
 # path to executables
-npm=/usr/local/bin/npm
-gulp=/usr/local/bin/gulp
+npm=npm
+gulp=gulp
 node.PATH=/usr/local/bin

--- a/build.xml
+++ b/build.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project default="xar" name="hsg-shell">
+    <property file="local.build.properties"/>
     <property file="build.properties"/>
     <xmlproperty file="expath-pkg.xml"/>
     <property name="project.version" value="${package(version)}"/>


### PR DESCRIPTION
Adds `local.build.properties` in any path to gitignore.   
Local paths can be declared in `local.build.properties`.