### PR TITLE
prevent extra ajax call breaking back button behaviour; addresses #273

### DIFF
--- a/modules/frus-toc-html.xqm
+++ b/modules/frus-toc-html.xqm
@@ -230,7 +230,8 @@ declare function toc:document-list($config as map(*), $node as element(tei:div),
                     <div>
                         <hr class="list"/>
                         <h4>
-                            <a href="{$href}" class="section-link">
+                            <!-- class="section-link" was triggering an extra ajax call -->
+                            <a href="{$href}">
                             {
                             	(: show a bracketed document number for volumes that don't use document numbers :)
                             	if (not(starts-with($doctitle, concat($docnumber, '.')))) then


### PR DESCRIPTION
not entirely happy with the solution as there's no ajax call at all but the upside is using back button works as expected; alternative would be commenting out https://github.com/HistoryAtState/hsg-shell/blob/master/resources/scripts/app.js#L118 to prevent double ajax calls but there's still quite a lot of hassle left to make modules/frus-ajax.xql observe start parameters, so not sure it's worth it