### PR TITLE
Fix 269

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -1460,15 +1460,7 @@ else if (matches($exist:path, '^/search/?')) then
         <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
             <forward url="{$exist:controller}/pages/{$page}"/>
             <view>
-                <forward url="{$exist:controller}/modules/view.xql">{
-                    (: templating's logic requires all parameters to be defined up front, so our
-                    conflation of volume IDs and "within" parameters has to be done at this stage :)
-                    let $within := request:get-parameter('within', ())
-                    let $volume-ids := for $w in $within return if (matches($w, '^frus\d')) then $w else ()
-                    for $volume-id in $volume-ids
-                    return
-                        <add-parameter name="volume-id" value="{$volume-id}"/>
-                }</forward>
+                <forward url="{$exist:controller}/modules/view.xql"/>
             </view>
     		<error-handler>
     			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -143,7 +143,9 @@ declare function search:load-sections($node, $model) {
         $html
 };
 
-declare function search:section-id-value-attribute($node, $model) {
+declare
+%templates:wrap
+function search:section-id-value-attribute($node, $model) {
     let $section-id := $model?section/id
     return
         attribute value { $section-id }
@@ -183,6 +185,7 @@ declare function search:load-volumes-within($node, $model) {
                 </volume>
         )
     }
+    let $c:= console:log($node)
     let $html := templates:process($node/*, map:new(($model, $content)))
     return
         $html
@@ -192,11 +195,14 @@ declare
     %templates:wrap
 function search:volume-id-value-attribute($node, $model) {
     let $volume-id := $model?volume/id
+    let $volume-title := $model?volume/title
     return
-        attribute value { $volume-id }
+        (attribute value { $volume-id },
+        $volume-title/string())
 };
 
-declare function search:volume-title($node, $model) {
+declare 
+function search:volume-title($node, $model) {
     let $volume-title := $model?volume/title
     return
         $volume-title/string()

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -144,18 +144,17 @@ declare function search:load-sections($node, $model) {
 };
 
 declare
+    %templates:wrap
 function search:section-attributes($node, $model, $within as xs:string+) {
-<input type="checkbox" name="within">
-{
+(
     attribute value { search:section-id-value-attribute($node, $model)},
     if (exists($within) and string-join($within) != "") then
         search:within-highlight-attribute($node, $model, $within) 
     else (),
     search:section-label($node, $model)
-}
+)
 </input>   
 };
-
 
 
 declare
@@ -205,13 +204,12 @@ declare function search:load-volumes-within($node, $model) {
 };
 
 declare
+    %templates:wrap
 function search:volume-attributes($node, $model) {
-<input type="checkbox" name="within" checked="checked">
-{
-        attribute value { search:volume-id-value-attribute($node, $model)},
-        search:volume-title($node, $model)
-        }
- </input>   
+(
+    attribute value { search:volume-id-value-attribute($node, $model)},
+    search:volume-title($node, $model)
+)
 };
 
 declare

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -145,7 +145,7 @@ declare function search:load-sections($node, $model) {
 
 declare
     %templates:wrap
-function search:section-attributes($node, $model, $within as xs:string+) {
+function search:section-attributes($node, $model, $within as xs:string*) {
 (
     attribute value { search:section-id-value-attribute($node, $model)},
     if (exists($within) and string-join($within) != "") then
@@ -153,7 +153,6 @@ function search:section-attributes($node, $model, $within as xs:string+) {
     else (),
     search:section-label($node, $model)
 )
-</input>   
 };
 
 

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -199,7 +199,6 @@ declare function search:load-volumes-within($node, $model) {
                 </volume>
         )
     }
-    let $c:= console:log($node)
     let $html := templates:process($node/*, map:new(($model, $content)))
     return
         $html

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -144,7 +144,21 @@ declare function search:load-sections($node, $model) {
 };
 
 declare
-%templates:wrap
+function search:section-attributes($node, $model, $within as xs:string+) {
+<input type="checkbox" name="within">
+{
+    attribute value { search:section-id-value-attribute($node, $model)},
+    if (exists($within) and string-join($within) != "") then
+        search:within-highlight-attribute($node, $model, $within) 
+    else (),
+    search:section-label($node, $model)
+}
+</input>   
+};
+
+
+
+declare
 function search:section-id-value-attribute($node, $model) {
     let $section-id := $model?section/id
     return
@@ -176,7 +190,7 @@ declare function search:plural-if-within-multiple-volumes($node, $model, $within
 declare function search:load-volumes-within($node, $model) {
     let $content := map { "volumes":
         (
-            for $volume-id in request:get-parameter('volume-id', ())
+            for $volume-id in distinct-values(request:get-parameter('volume-id', ()))
             order by $volume-id
             return
                 <volume>
@@ -192,20 +206,23 @@ declare function search:load-volumes-within($node, $model) {
 };
 
 declare
-    %templates:wrap
+function search:volume-attributes($node, $model) {
+<input type="checkbox" name="within" checked="checked">
+{
+        attribute value { search:volume-id-value-attribute($node, $model)},
+        search:volume-title($node, $model)
+        }
+ </input>   
+};
+
+declare
 function search:volume-id-value-attribute($node, $model) {
-    let $volume-id := $model?volume/id
-    let $volume-title := $model?volume/title
-    return
-        (attribute value { $volume-id },
-        $volume-title/string())
+    $model?volume/id
 };
 
 declare 
 function search:volume-title($node, $model) {
-    let $volume-title := $model?volume/title
-    return
-        $volume-title/string()
+    $model?volume/title/string()
 };
 
 declare

--- a/pages/search/index.html
+++ b/pages/search/index.html
@@ -51,7 +51,7 @@
                         </div>
                         <div data-template="app:if-parameter-set" data-template-param="volume-id">
                             <p class="hsg-search-help">
-                                <a href="$app/search">Clear these checkboxes</a>, or <a
+                                <a href="$app/search">Clear this search</a>, or <a
                                     href="$app/search/select-volumes"
                                     data-template="search:select-volumes-link"> change selection</a>
                                 of <em>Foreign Relations</em> volumes within which to search</p>

--- a/pages/search/index.html
+++ b/pages/search/index.html
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<div data-template="templates:surround" data-template-with="templates/site.html"
-    data-template-at="content">
+<div data-template="templates:surround" data-template-with="templates/site.html" data-template-at="content">
     <div id="static-title" class="hidden">Search</div>
     <div class="row">
         <div class="hsg-breadcrumb-wrapper">
@@ -23,31 +22,24 @@
                         phrase, boolean, wildcard, and proximity options.</p>
                     <form method="get" action="$app/search">
                         <p class="form-group">
-                            <input type="text" name="q" placeholder="Search..." class="form-control"
-                                id="q" data-template="templates:form-control"/>
+                            <input type="text" name="q" placeholder="Search..." class="form-control" id="q" data-template="templates:form-control"/>
                         </p>
                         <div data-template="search:load-sections">
                             <p>To limit your results to certain parts of the website, check the
                                 appropriate box(es), and then click “Search”:</p>
                             <div class="hsg-search-inputs">
-                                <label class="hsg-search-input-label" data-template="templates:each"
-                                    data-template-from="sections" data-template-to="section">
+                                <label class="hsg-search-input-label" data-template="templates:each" data-template-from="sections" data-template-to="section">
                                     <input type="checkbox" name="within" data-template="search:section-attributes"/>
                                 </label>
                             </div>
                         </div>
                         <div data-template="search:load-volumes-within">
-                            <div data-template="app:if-parameter-set"
-                                data-template-param="volume-id">
+                            <div data-template="app:if-parameter-set" data-template-param="volume-id">
                                 <p>Restrict search to the following <em>Foreign Relations</em>
-                                    volume<span data-template="app:if-parameter-set"
-                                        data-template-param="within">
-                                        <span
-                                            data-template="search:plural-if-within-multiple-volumes"
-                                        />
+                                    volume<span data-template="app:if-parameter-set" data-template-param="within">
+                                        <span data-template="search:plural-if-within-multiple-volumes"/>
                                     </span>:</p>
-                                <div class="hsg-search-inputs" data-template="templates:each"
-                                    data-template-from="volumes" data-template-to="volume">
+                                <div class="hsg-search-inputs" data-template="templates:each" data-template-from="volumes" data-template-to="volume">
                                     <label class="hsg-search-input-label">
                                         <input type="checkbox" name="within" checked="checked" data-template="search:volume-attributes"/>
                                     </label>
@@ -56,26 +48,20 @@
                         </div>
                         <div data-template="app:if-parameter-set" data-template-param="volume-id">
                             <p class="hsg-search-help">
-                                <a href="$app/search">Clear these checkboxes</a>, or <a
-                                    href="$app/search/select-volumes"
-                                    data-template="search:select-volumes-link"> change selection</a>
+                                <a href="$app/search">Clear these checkboxes</a>, or <a href="$app/search/select-volumes" data-template="search:select-volumes-link"> change selection</a>
                                 of <em>Foreign Relations</em> volumes within which to search</p>
                         </div>
                         <div data-template="app:if-parameter-unset" data-template-param="volume-id">
                             <div data-template="app:if-parameter-set" data-template-param="q">
-                                <div data-template="app:if-parameter-set"
-                                    data-template-param="within">
+                                <div data-template="app:if-parameter-set" data-template-param="within">
                                     <p>
-                                        <a href="$app/search">Reset this search</a> or <a
-                                            href="$app/search/select-volumes">choose <em>Foreign
+                                        <a href="$app/search">Reset this search</a> or <a href="$app/search/select-volumes">choose <em>Foreign
                                                 Relations</em> volumes</a>
                                     </p>
                                 </div>
-                                <div data-template="app:if-parameter-unset"
-                                    data-template-param="within">
+                                <div data-template="app:if-parameter-unset" data-template-param="within">
                                     <p class="hsg-search-help">
-                                        <a href="$app/search/select-volumes"
-                                            data-template="search:select-volumes-link">Restrict this
+                                        <a href="$app/search/select-volumes" data-template="search:select-volumes-link">Restrict this
                                             search to specific <em>Foreign Relations</em>
                                             volumes</a>
                                     </p>
@@ -97,17 +83,14 @@
                 <section class="hsg-search-section">
                     <div data-template="app:if-parameter-set" data-template-param="q">
                         <div data-template="search:load-results">
-                            <h1 class="hsg-search-result-message">Results for keyword search <span
-                                class="hsg-search-query"><span data-template="search:q"
-                                /></span>, sorted by relevance.</h1>
+                            <h1 class="hsg-search-result-message">Results for keyword search <span class="hsg-search-query">
+                                    <span data-template="search:q"/>
+                                </span>, sorted by relevance.</h1>
                             <p data-template="search:result-count-summary"/>
                             <nav>
-                                <ul class="pagination" data-template="search:paginate"
-                                    data-template-per-page="10" data-template-max-pages="10"
-                                    data-template-min-hits="1"/>
+                                <ul class="pagination" data-template="search:paginate" data-template-per-page="10" data-template-max-pages="10" data-template-min-hits="1"/>
                             </nav>
-                            <div class="hsg-search-result" data-template="templates:each"
-                                data-template-from="results" data-template-to="result">
+                            <div class="hsg-search-result" data-template="templates:each" data-template-from="results" data-template-to="result">
                                 <h3 class="hsg-search-result-heading">
                                     <span data-template="search:result-heading"/>
                                 </h3>
@@ -119,9 +102,7 @@
                                 </p>
                             </div>
                             <nav>
-                                <ul class="pagination" data-template="search:paginate"
-                                    data-template-per-page="10" data-template-max-pages="10"
-                                    data-template-min-hits="1"/>
+                                <ul class="pagination" data-template="search:paginate" data-template-per-page="10" data-template-max-pages="10" data-template-min-hits="1"/>
                             </nav>
                         </div>
                     </div>

--- a/pages/search/index.html
+++ b/pages/search/index.html
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<div data-template="templates:surround" data-template-with="templates/site.html" data-template-at="content">
+<div data-template="templates:surround" data-template-with="templates/site.html"
+    data-template-at="content">
     <div id="static-title" class="hidden">Search</div>
     <div class="row">
         <div class="hsg-breadcrumb-wrapper">
@@ -22,24 +23,31 @@
                         phrase, boolean, wildcard, and proximity options.</p>
                     <form method="get" action="$app/search">
                         <p class="form-group">
-                            <input type="text" name="q" placeholder="Search..." class="form-control" id="q" data-template="templates:form-control"/>
+                            <input type="text" name="q" placeholder="Search..." class="form-control"
+                                id="q" data-template="templates:form-control"/>
                         </p>
                         <div data-template="search:load-sections">
                             <p>To limit your results to certain parts of the website, check the
                                 appropriate box(es), and then click “Search”:</p>
                             <div class="hsg-search-inputs">
-                                <label class="hsg-search-input-label" data-template="templates:each" data-template-from="sections" data-template-to="section">
+                                <label class="hsg-search-input-label" data-template="templates:each"
+                                    data-template-from="sections" data-template-to="section">
                                     <input type="checkbox" name="within" data-template="search:section-attributes"/>
                                 </label>
                             </div>
                         </div>
                         <div data-template="search:load-volumes-within">
-                            <div data-template="app:if-parameter-set" data-template-param="volume-id">
+                            <div data-template="app:if-parameter-set"
+                                data-template-param="volume-id">
                                 <p>Restrict search to the following <em>Foreign Relations</em>
-                                    volume<span data-template="app:if-parameter-set" data-template-param="within">
-                                        <span data-template="search:plural-if-within-multiple-volumes"/>
+                                    volume<span data-template="app:if-parameter-set"
+                                        data-template-param="within">
+                                        <span
+                                            data-template="search:plural-if-within-multiple-volumes"
+                                        />
                                     </span>:</p>
-                                <div class="hsg-search-inputs" data-template="templates:each" data-template-from="volumes" data-template-to="volume">
+                                <div class="hsg-search-inputs" data-template="templates:each"
+                                    data-template-from="volumes" data-template-to="volume">
                                     <label class="hsg-search-input-label">
                                         <input type="checkbox" name="within" checked="checked" data-template="search:volume-attributes"/>
                                     </label>
@@ -48,20 +56,26 @@
                         </div>
                         <div data-template="app:if-parameter-set" data-template-param="volume-id">
                             <p class="hsg-search-help">
-                                <a href="$app/search">Clear these checkboxes</a>, or <a href="$app/search/select-volumes" data-template="search:select-volumes-link"> change selection</a>
+                                <a href="$app/search">Clear these checkboxes</a>, or <a
+                                    href="$app/search/select-volumes"
+                                    data-template="search:select-volumes-link"> change selection</a>
                                 of <em>Foreign Relations</em> volumes within which to search</p>
                         </div>
                         <div data-template="app:if-parameter-unset" data-template-param="volume-id">
                             <div data-template="app:if-parameter-set" data-template-param="q">
-                                <div data-template="app:if-parameter-set" data-template-param="within">
+                                <div data-template="app:if-parameter-set"
+                                    data-template-param="within">
                                     <p>
-                                        <a href="$app/search">Reset this search</a> or <a href="$app/search/select-volumes">choose <em>Foreign
+                                        <a href="$app/search">Reset this search</a> or <a
+                                            href="$app/search/select-volumes">choose <em>Foreign
                                                 Relations</em> volumes</a>
                                     </p>
                                 </div>
-                                <div data-template="app:if-parameter-unset" data-template-param="within">
+                                <div data-template="app:if-parameter-unset"
+                                    data-template-param="within">
                                     <p class="hsg-search-help">
-                                        <a href="$app/search/select-volumes" data-template="search:select-volumes-link">Restrict this
+                                        <a href="$app/search/select-volumes"
+                                            data-template="search:select-volumes-link">Restrict this
                                             search to specific <em>Foreign Relations</em>
                                             volumes</a>
                                     </p>
@@ -83,14 +97,17 @@
                 <section class="hsg-search-section">
                     <div data-template="app:if-parameter-set" data-template-param="q">
                         <div data-template="search:load-results">
-                            <h1 class="hsg-search-result-message">Results for keyword search <span class="hsg-search-query">
-                                    <span data-template="search:q"/>
-                                </span>, sorted by relevance.</h1>
+                            <h1 class="hsg-search-result-message">Results for keyword search <span
+                                class="hsg-search-query"><span data-template="search:q"
+                                /></span>, sorted by relevance.</h1>
                             <p data-template="search:result-count-summary"/>
                             <nav>
-                                <ul class="pagination" data-template="search:paginate" data-template-per-page="10" data-template-max-pages="10" data-template-min-hits="1"/>
+                                <ul class="pagination" data-template="search:paginate"
+                                    data-template-per-page="10" data-template-max-pages="10"
+                                    data-template-min-hits="1"/>
                             </nav>
-                            <div class="hsg-search-result" data-template="templates:each" data-template-from="results" data-template-to="result">
+                            <div class="hsg-search-result" data-template="templates:each"
+                                data-template-from="results" data-template-to="result">
                                 <h3 class="hsg-search-result-heading">
                                     <span data-template="search:result-heading"/>
                                 </h3>
@@ -102,7 +119,9 @@
                                 </p>
                             </div>
                             <nav>
-                                <ul class="pagination" data-template="search:paginate" data-template-per-page="10" data-template-max-pages="10" data-template-min-hits="1"/>
+                                <ul class="pagination" data-template="search:paginate"
+                                    data-template-per-page="10" data-template-max-pages="10"
+                                    data-template-min-hits="1"/>
                             </nav>
                         </div>
                     </div>

--- a/pages/search/index.html
+++ b/pages/search/index.html
@@ -32,7 +32,7 @@
                             <div class="hsg-search-inputs">
                                 <label class="hsg-search-input-label" data-template="templates:each"
                                     data-template-from="sections" data-template-to="section">
-                                    <input type="checkbox" name="within" data-template="search:section-attributes"/>
+                                    <input type="checkbox" name="within" data-template="search:section-checkbox-value-attribute-and-title"/>
                                 </label>
                             </div>
                         </div>
@@ -40,16 +40,11 @@
                             <div data-template="app:if-parameter-set"
                                 data-template-param="volume-id">
                                 <p>Restrict search to the following <em>Foreign Relations</em>
-                                    volume<span data-template="app:if-parameter-set"
-                                        data-template-param="within">
-                                        <span
-                                            data-template="search:plural-if-within-multiple-volumes"
-                                        />
-                                    </span>:</p>
+                                    volume(s):</p>
                                 <div class="hsg-search-inputs" data-template="templates:each"
                                     data-template-from="volumes" data-template-to="volume">
                                     <label class="hsg-search-input-label">
-                                        <input type="checkbox" name="within" checked="checked" data-template="search:volume-attributes"/>
+                                        <input type="checkbox" name="volume-id" checked="checked" data-template="search:volume-checkbox-value-attribute-and-title"/>
                                     </label>
                                 </div>
                             </div>
@@ -67,7 +62,8 @@
                                     data-template-param="within">
                                     <p>
                                         <a href="$app/search">Reset this search</a> or <a
-                                            href="$app/search/select-volumes">choose <em>Foreign
+                                            href="$app/search/select-volumes"
+                                            data-template="search:select-volumes-link">choose <em>Foreign
                                                 Relations</em> volumes</a>
                                     </p>
                                 </div>

--- a/pages/search/index.html
+++ b/pages/search/index.html
@@ -29,27 +29,19 @@
                                 appropriate box(es), and then click “Search”:</p>
                             <div class="hsg-search-inputs">
                                 <label class="hsg-search-input-label" data-template="templates:each" data-template-from="sections" data-template-to="section">
-                                    <input type="checkbox" name="within">
-                                        <span data-template="search:section-id-value-attribute"/>
-                                        <span data-template="app:if-parameter-set" data-template-param="within">
-                                            <span data-template="search:within-highlight-attribute"/>
-                                        </span>
-                                        <span data-template="search:section-label"/>
-                                    </input>
+                                    <input type="checkbox" name="within" data-template="search:section-attributes"/>
                                 </label>
                             </div>
                         </div>
                         <div data-template="search:load-volumes-within">
                             <div data-template="app:if-parameter-set" data-template-param="volume-id">
                                 <p>Restrict search to the following <em>Foreign Relations</em>
-                                        volume<span data-template="app:if-parameter-set" data-template-param="within">
+                                    volume<span data-template="app:if-parameter-set" data-template-param="within">
                                         <span data-template="search:plural-if-within-multiple-volumes"/>
                                     </span>:</p>
                                 <div class="hsg-search-inputs" data-template="templates:each" data-template-from="volumes" data-template-to="volume">
                                     <label class="hsg-search-input-label">
-                                        <input type="checkbox" name="within" checked="checked" data-template="search:volume-id-value-attribute">
-                                            <span data-template="search:volume-title"/>
-                                        </input>
+                                        <input type="checkbox" name="within" checked="checked" data-template="search:volume-attributes"/>
                                     </label>
                                 </div>
                             </div>
@@ -78,7 +70,7 @@
                             <div data-template="app:if-parameter-unset" data-template-param="q">
                                 <p class="hsg-search-help">
                                     <a href="$app/search/select-volumes">Select specific <em>Foreign
-                                            Relations</em> volumes to search</a>
+                                        Relations</em> volumes to search</a>
                                 </p>
                             </div>
                         </div>
@@ -87,7 +79,7 @@
                         </button>
                     </form>
                 </section>
-
+                
                 <section class="hsg-search-section">
                     <div data-template="app:if-parameter-set" data-template-param="q">
                         <div data-template="search:load-results">

--- a/pages/search/index.html
+++ b/pages/search/index.html
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<div data-template="templates:surround" data-template-with="templates/site.html"
-    data-template-at="content">
+<div data-template="templates:surround" data-template-with="templates/site.html" data-template-at="content">
     <div id="static-title" class="hidden">Search</div>
     <div class="row">
         <div class="hsg-breadcrumb-wrapper">
@@ -23,36 +22,32 @@
                         phrase, boolean, wildcard, and proximity options.</p>
                     <form method="get" action="$app/search">
                         <p class="form-group">
-                            <input type="text" name="q" placeholder="Search..." class="form-control"
-                                id="q" data-template="templates:form-control"/>
+                            <input type="text" name="q" placeholder="Search..." class="form-control" id="q" data-template="templates:form-control"/>
                         </p>
                         <div data-template="search:load-sections">
                             <p>To limit your results to certain parts of the website, check the
                                 appropriate box(es), and then click “Search”:</p>
                             <div class="hsg-search-inputs">
-                                <label class="hsg-search-input-label" data-template="templates:each"
-                                    data-template-from="sections" data-template-to="section">
-                                    <input type="checkbox" name="within"><span data-template="search:section-id-value-attribute"/><span data-template="app:if-parameter-set"
-                                            data-template-param="within"><span data-template="search:within-highlight-attribute"/></span>
+                                <label class="hsg-search-input-label" data-template="templates:each" data-template-from="sections" data-template-to="section">
+                                    <input type="checkbox" name="within">
+                                        <span data-template="search:section-id-value-attribute"/>
+                                        <span data-template="app:if-parameter-set" data-template-param="within">
+                                            <span data-template="search:within-highlight-attribute"/>
+                                        </span>
                                         <span data-template="search:section-label"/>
                                     </input>
                                 </label>
                             </div>
                         </div>
                         <div data-template="search:load-volumes-within">
-                            <div data-template="app:if-parameter-set"
-                                data-template-param="volume-id">
+                            <div data-template="app:if-parameter-set" data-template-param="volume-id">
                                 <p>Restrict search to the following <em>Foreign Relations</em>
-                                        volume<span data-template="app:if-parameter-set"
-                                        data-template-param="within">
-                                        <span
-                                            data-template="search:plural-if-within-multiple-volumes"
-                                        />
+                                        volume<span data-template="app:if-parameter-set" data-template-param="within">
+                                        <span data-template="search:plural-if-within-multiple-volumes"/>
                                     </span>:</p>
-                                <div class="hsg-search-inputs" data-template="templates:each"
-                                    data-template-from="volumes" data-template-to="volume">
+                                <div class="hsg-search-inputs" data-template="templates:each" data-template-from="volumes" data-template-to="volume">
                                     <label class="hsg-search-input-label">
-                                        <input type="checkbox" name="within" checked="checked"><span data-template="search:volume-id-value-attribute"/>
+                                        <input type="checkbox" name="within" checked="checked" data-template="search:volume-id-value-attribute">
                                             <span data-template="search:volume-title"/>
                                         </input>
                                     </label>
@@ -61,26 +56,20 @@
                         </div>
                         <div data-template="app:if-parameter-set" data-template-param="volume-id">
                             <p class="hsg-search-help">
-                                <a href="$app/search">Clear these checkboxes</a>, or <a
-                                    href="$app/search/select-volumes"
-                                    data-template="search:select-volumes-link"> change selection</a>
+                                <a href="$app/search">Clear these checkboxes</a>, or <a href="$app/search/select-volumes" data-template="search:select-volumes-link"> change selection</a>
                                 of <em>Foreign Relations</em> volumes within which to search</p>
                         </div>
                         <div data-template="app:if-parameter-unset" data-template-param="volume-id">
                             <div data-template="app:if-parameter-set" data-template-param="q">
-                                <div data-template="app:if-parameter-set"
-                                    data-template-param="within">
+                                <div data-template="app:if-parameter-set" data-template-param="within">
                                     <p>
-                                        <a href="$app/search">Reset this search</a> or <a
-                                            href="$app/search/select-volumes">choose <em>Foreign
+                                        <a href="$app/search">Reset this search</a> or <a href="$app/search/select-volumes">choose <em>Foreign
                                                 Relations</em> volumes</a>
                                     </p>
                                 </div>
-                                <div data-template="app:if-parameter-unset"
-                                    data-template-param="within">
+                                <div data-template="app:if-parameter-unset" data-template-param="within">
                                     <p class="hsg-search-help">
-                                        <a href="$app/search/select-volumes"
-                                            data-template="search:select-volumes-link">Restrict this
+                                        <a href="$app/search/select-volumes" data-template="search:select-volumes-link">Restrict this
                                             search to specific <em>Foreign Relations</em>
                                             volumes</a>
                                     </p>
@@ -102,17 +91,14 @@
                 <section class="hsg-search-section">
                     <div data-template="app:if-parameter-set" data-template-param="q">
                         <div data-template="search:load-results">
-                            <h1 class="hsg-search-result-message">Results for keyword search <span
-                                    class="hsg-search-query"><span data-template="search:q"
-                                /></span>, sorted by relevance.</h1>
+                            <h1 class="hsg-search-result-message">Results for keyword search <span class="hsg-search-query">
+                                    <span data-template="search:q"/>
+                                </span>, sorted by relevance.</h1>
                             <p data-template="search:result-count-summary"/>
                             <nav>
-                                <ul class="pagination" data-template="search:paginate"
-                                    data-template-per-page="10" data-template-max-pages="10"
-                                    data-template-min-hits="1"/>
+                                <ul class="pagination" data-template="search:paginate" data-template-per-page="10" data-template-max-pages="10" data-template-min-hits="1"/>
                             </nav>
-                            <div class="hsg-search-result" data-template="templates:each"
-                                data-template-from="results" data-template-to="result">
+                            <div class="hsg-search-result" data-template="templates:each" data-template-from="results" data-template-to="result">
                                 <h3 class="hsg-search-result-heading">
                                     <span data-template="search:result-heading"/>
                                 </h3>
@@ -124,9 +110,7 @@
                                 </p>
                             </div>
                             <nav>
-                                <ul class="pagination" data-template="search:paginate"
-                                    data-template-per-page="10" data-template-max-pages="10"
-                                    data-template-min-hits="1"/>
+                                <ul class="pagination" data-template="search:paginate" data-template-per-page="10" data-template-max-pages="10" data-template-min-hits="1"/>
                             </nav>
                         </div>
                     </div>


### PR DESCRIPTION
makes the search page independent of whitespace in html template
aggregates all template calls previously handled via nested dummy `<span>` elements