### PR TITLE
Migrate from the sort index to the memsort module

### DIFF
--- a/modules/rebuild-dates-sort-index.xql
+++ b/modules/rebuild-dates-sort-index.xql
@@ -3,17 +3,12 @@ xquery version "3.1";
 declare namespace frus="http://history.state.gov/frus/ns/1.0";
 declare namespace tei="http://www.tei-c.org/ns/1.0";
 
-sort:remove-index("doc-dateTime-min-asc"),
-sort:create-index-callback(
-    "doc-dateTime-min-asc", 
-    collection("/db/apps/frus/volumes")//tei:div/@frus:doc-dateTime-min, 
-    function($date) { xs:dateTime($date) }, 
-    <options order="ascending"/>
-),
-sort:remove-index("doc-dateTime-max-desc"),
-sort:create-index-callback(
-    "doc-dateTime-max-desc", 
-    collection("/db/apps/frus/volumes")//tei:div/@frus:doc-dateTime-max, 
-    function($date) { xs:dateTime($date) }, 
-    <options order="descending"/>
+import module namespace memsort="http://exist-db.org/xquery/memsort" at "java:org.existdb.memsort.SortModule";
+
+memsort:create(
+    "doc-dateTime-min",
+    collection("/db/apps/frus/volumes")//tei:div,
+    function($div) {
+        $div/@frus:doc-dateTime-min/xs:dateTime(.)
+    }
 )

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -15,13 +15,14 @@ import module namespace functx = "http://www.functx.com";
 import module namespace sort="http://exist-db.org/xquery/sort" at "java:org.exist.xquery.modules.sort.SortModule";
 :)
 import module namespace memsort="http://exist-db.org/xquery/memsort" at "java:org.existdb.memsort.SortModule";
+import module namespace cache="http://exist-db.org/xquery/cache" at "java:org.exist.xquery.modules.cache.CacheModule";
 
 declare namespace tei="http://www.tei-c.org/ns/1.0";
 declare namespace frus="http://history.state.gov/frus/ns/1.0";
 
 declare variable $search:MAX_HITS_SHOWN := 1000;
 
-declare variable $search:ft-query-options := 
+declare variable $search:ft-query-options :=
     <options>
         <default-operator>and</default-operator>
         <phrase-slop>0</phrase-slop>

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -11,7 +11,10 @@ import module namespace fd="http://history.state.gov/ns/site/hsg/frus-dates" at 
 import module namespace config="http://history.state.gov/ns/site/hsg/config" at "config.xqm";
 import module namespace fh = "http://history.state.gov/ns/site/hsg/frus-html" at "frus-html.xqm";
 import module namespace functx = "http://www.functx.com";
+(:
 import module namespace sort="http://exist-db.org/xquery/sort" at "java:org.exist.xquery.modules.sort.SortModule";
+:)
+import module namespace memsort="http://exist-db.org/xquery/memsort" at "java:org.existdb.memsort.SortModule";
 
 declare namespace tei="http://www.tei-c.org/ns/1.0";
 declare namespace frus="http://history.state.gov/frus/ns/1.0";
@@ -681,8 +684,9 @@ declare function search:sort($hits as element()*, $sort-by as xs:string) {
             return
                 (
                     for $hit in $dated
-                    order by sort:index("doc-dateTime-min-asc", $hit/@frus:doc-dateTime-min)
+                    order by memsort:get("doc-dateTime-min", $hit) ascending empty greatest, ft:score($hit) descending
                     (:
+                    order by sort:index("doc-dateTime-min-asc", $hit/@frus:doc-dateTime-min)
                     order by $hit/@frus:doc-dateTime-min
                     :)
                     return
@@ -699,8 +703,9 @@ declare function search:sort($hits as element()*, $sort-by as xs:string) {
             return
                 (
                     for $hit in $dated
-                    order by sort:index("doc-dateTime-min-desc", $hit/@frus:doc-dateTime-min)
+                    order by memsort:get("doc-dateTime-min", $hit) descending empty least, ft:score($hit) descending
                     (:
+                    order by sort:index("doc-dateTime-min-desc", $hit/@frus:doc-dateTime-min)
                     order by $hit/@frus:doc-dateTime-min descending
                     :)
                     return

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -680,43 +680,15 @@ function search:load-results($node as node(), $model as map(*), $q as xs:string?
 declare function search:sort($hits as element()*, $sort-by as xs:string) {
     switch ($sort-by)
         case "date-asc" return
-            let $dated := $hits[@frus:doc-dateTime-min]
-            let $undated := $hits except $dated
+            for $hit in $hits
+            order by memsort:get("doc-dateTime-min", $hit) ascending empty greatest, ft:score($hit) descending
             return
-                (
-                    for $hit in $dated
-                    order by memsort:get("doc-dateTime-min", $hit) ascending empty greatest, ft:score($hit) descending
-                    (:
-                    order by sort:index("doc-dateTime-min-asc", $hit/@frus:doc-dateTime-min)
-                    order by $hit/@frus:doc-dateTime-min
-                    :)
-                    return
-                        $hit
-                    ,
-                    for $hit in $undated
-                    order by ft:score($hit) descending
-                    return
-                        $hit
-                )
+                $hit
         case "date-desc" return
-            let $dated := $hits[@frus:doc-dateTime-min]
-            let $undated := $hits except $dated
+            for $hit in $hits
+            order by memsort:get("doc-dateTime-min", $hit) descending empty least, ft:score($hit) descending
             return
-                (
-                    for $hit in $dated
-                    order by memsort:get("doc-dateTime-min", $hit) descending empty least, ft:score($hit) descending
-                    (:
-                    order by sort:index("doc-dateTime-min-desc", $hit/@frus:doc-dateTime-min)
-                    order by $hit/@frus:doc-dateTime-min descending
-                    :)
-                    return
-                        $hit
-                    ,
-                    for $hit in $undated
-                    order by ft:score($hit) descending
-                    return
-                        $hit
-                )
+                $hit
         default (: case "relevance" :) return
             for $hit in $hits
             order by ft:score($hit) descending


### PR DESCRIPTION
The new history.state.gov date search interface launched in December 2017 relied on eXist's "sort index" to speed date searches by pre-sorting all documents into chronological order based on the new date metadata. 

This PR replaces our use of the sort index with the new [memsort module](https://github.com/wolfgangmm/memsort), created for us by @wolfgangmm. The improvements are as follows:

1. The memsort module stores its indexes in memory, delivering major performance improvements over the sort module, which stored its index on disk. In our testing and now in production, date searches perform as quickly as plain relevance searches. 
2. The old sort index required us to create two indexes: one for normal chronological order (ascending) and one for reverse chronological order (descending). The new memsort module handles both tasks with a single index.
3. A bug caused disk usage to grow after each index run, and when disk space was exhausted, there were cascading effects on our other scheduled jobs, such as our polling of the Twitter API for the tweets listed on the history.state.gov homepage. 

Upgrade directions for hsg-project users: (1) Fetch all updates to ensure you get https://github.com/HistoryAtState/hsg-project/pull/39, then (2) wipe and repopulate, and (3) deploy all packages. Then you will be using the new memsort module.