### PR TITLE
Administrative timeline soft launch

### DIFF
--- a/app/templates/site.html
+++ b/app/templates/site.html
@@ -109,11 +109,11 @@
                                     <a href="$app/departmenthistory">Overview</a>
                                 </li>
                                 <li>
-                                    <a href="$app/departmenthistory/short-history">A Short History of the Department</a>
+                                    <a href="$app/departmenthistory/timeline">Administrative Timeline</a>
                                 </li>
                                 <li>
-                                    <a href="$app/departmenthistory/people/secretaries">Biographies of the Secretaries of
-                                        State</a>
+                                    <a href="$app/departmenthistory/people/secretaries">Biographies
+                                        of the Secretaries of State</a>
                                 </li>
                                 <li>
                                     <a href="$app/departmenthistory/people/principals-chiefs">Principal Officers and Chiefs of
@@ -180,6 +180,9 @@
                                 </li>
                                 <li>
                                     <a href="$app/open">Open Government Initiative</a>
+                                </li>
+                                <li>
+                                    <a href="$app/departmenthistory/short-history">A Short History of the Department</a>
                                 </li>
                             </ul>
                         </li>

--- a/controller.xql
+++ b/controller.xql
@@ -533,6 +533,41 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
     let $fragments := tokenize(substring-after($exist:path, '/departmenthistory/'), '/')[. ne '']
     return
         switch ($fragments[1])
+            case "timeline" return
+                if ($fragments[2]) then
+                    let $page := 'departmenthistory/timeline/section.html'
+                    let $section-id := $fragments[2]
+                    return
+                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                            <forward url="{$exist:controller}/pages/{$page}"/>
+                            <view>
+                                <forward url="{$exist:controller}/modules/view.xql">
+                                    <add-parameter name="publication-id" value="timeline"/>
+                                    <add-parameter name="document-id" value="timeline"/>
+                                    <add-parameter name="section-id" value="{$section-id}"/>
+                                </forward>
+                            </view>
+                    		<error-handler>
+                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                    			<forward url="{$exist:controller}/modules/view.xql"/>
+                    		</error-handler>
+                        </dispatch>
+                else
+                    let $page := 'departmenthistory/timeline/index.html'
+                    return
+                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                            <forward url="{$exist:controller}/pages/{$page}"/>
+                            <view>
+                                <forward url="{$exist:controller}/modules/view.xql">
+                                    <add-parameter name="publication-id" value="timeline"/>
+                                    <add-parameter name="document-id" value="timeline"/>
+                                </forward>
+                            </view>
+                    		<error-handler>
+                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                    			<forward url="{$exist:controller}/modules/view.xql"/>
+                    		</error-handler>
+                        </dispatch>
             case "short-history" return
                 if ($fragments[2]) then
                     let $page := 'departmenthistory/short-history/section.html'

--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -258,8 +258,9 @@ declare variable $config:PUBLICATIONS :=
         "timeline": map {
             "collection": $config:ADMINISTRATIVE_TIMELINE_COL,
             "select-document": function($document-id) { doc($config:ADMINISTRATIVE_TIMELINE_COL || '/' || $document-id || '.xml') },
-            "select-section": function($document-id, $section-id) { doc($config:ADMINISTRATIVE_TIMELINE_COL || '/' || $document-id || '.xml')/id($section-id) },
-            "html-href": function($document-id, $section-id) { "$app/departmenthistory/" || string-join(($document-id, $section-id), '/') },
+            "select-section": function($document-id, $section-id) { doc($config:ADMINISTRATIVE_TIMELINE_COL || '/' || $document-id || '.xml')/id('chapter_' || $section-id) },
+            "html-href": function($document-id, $section-id) { "$app/departmenthistory/" || string-join(($document-id, substring-after($section-id, 'chapter_')), '/') },
+            "url-fragment": function($div) { if (starts-with($div/@xml:id, 'chapter_')) then substring-after($div/@xml:id, 'chapter_') else $div/@xml:id/string() },
             "odd": "frus.odd",
             "transform": function($xml, $parameters) { pm-frus:transform($xml,  map:new(($parameters, map:entry("document-list", true())))) },
             "title": "Administrative Timeline - Department History",

--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -79,6 +79,7 @@ declare variable $config:CONFERENCES_ARTICLES_COL := $config:CONFERENCES_COL || 
 declare variable $config:COUNTRIES_COL := "/db/apps/rdcr";
 declare variable $config:COUNTRIES_ARTICLES_COL := "/db/apps/rdcr/articles";
 declare variable $config:SHORT_HISTORY_COL := "/db/apps/other-publications/short-history";
+declare variable $config:ADMINISTRATIVE_TIMELINE_COL := "/db/apps/administrative-timeline/timeline";
 declare variable $config:SECRETARY_BIOS_COL := "/db/apps/other-publications/secretary-bios";
 declare variable $config:MILESTONES_COL := "/db/apps/milestones/chapters";
 declare variable $config:EDUCATION_COL := "/db/apps/other-publications/education/introductions";
@@ -254,6 +255,16 @@ declare variable $config:PUBLICATIONS :=
             "title": "Short History - Department History",
             "base-path": function($document-id, $section-id) { "short-history" }
         },
+        "timeline": map {
+            "collection": $config:ADMINISTRATIVE_TIMELINE_COL,
+            "select-document": function($document-id) { doc($config:ADMINISTRATIVE_TIMELINE_COL || '/' || $document-id || '.xml') },
+            "select-section": function($document-id, $section-id) { doc($config:ADMINISTRATIVE_TIMELINE_COL || '/' || $document-id || '.xml')/id($section-id) },
+            "html-href": function($document-id, $section-id) { "$app/departmenthistory/" || string-join(($document-id, $section-id), '/') },
+            "odd": "frus.odd",
+            "transform": function($xml, $parameters) { pm-frus:transform($xml,  map:new(($parameters, map:entry("document-list", true())))) },
+            "title": "Administrative Timeline - Department History",
+            "base-path": function($document-id, $section-id) { "timeline" }
+        },
         "faq": map {
             "collection": $config:FAQ_COL,
             "select-document": function($document-id) { doc($config:FAQ_COL || '/' || $document-id || '.xml') },
@@ -320,6 +331,7 @@ declare variable $config:PUBLICATION-COLLECTIONS :=
         $config:FRUS_METADATA_COL: "frus",
         $config:BUILDINGS_COL: "buildings",
         $config:SHORT_HISTORY_COL: "short-history",
+        $config:ADMINISTRATIVE_TIMELINE_COL: "timeline",
         $config:FAQ_COL: "faq",
         $config:HAC_COL: "hac",
         $config:EDUCATION_COL: "education",

--- a/modules/frus-ajax.xql
+++ b/modules/frus-ajax.xql
@@ -101,11 +101,15 @@ return
             map {
                 "doc": $doc,
                 "next":
-                    if ($next) then
+                    if ($next and map:contains(map:get($config:PUBLICATIONS, $publication-id), 'url-fragment')) then
+                        map:get($config:PUBLICATIONS, $publication-id)?url-fragment($next)
+                    else if ($next) then
                         $next/@xml:id/string()
                     else (),
                 "previous":
-                    if ($prev) then
+                    if ($prev and map:contains(map:get($config:PUBLICATIONS, $publication-id), 'url-fragment')) then
+                        map:get($config:PUBLICATIONS, $publication-id)?url-fragment($prev)
+                    else if ($prev) then
                         $prev/@xml:id/string()
                     else (),
                 "title": $doc-title,

--- a/modules/frus-ajax.xql
+++ b/modules/frus-ajax.xql
@@ -38,6 +38,7 @@ let $publication-id :=
             switch ($volume)
                 case 'buildings' return 'buildings'
                 case 'short-history' return 'short-history'
+                case 'timeline' return 'timeline'
                 default return $publication
         default return $publication
 let $log := console:log("publication: " || $publication || ", volume: " || $volume)

--- a/modules/frus-toc-html.xqm
+++ b/modules/frus-toc-html.xqm
@@ -135,7 +135,7 @@ declare function toc:toc-div($model as map(*), $node as element(tei:div), $curre
                         concat('s ', $first, '-', $last)
                 return
                     concat(' (Document', $document, ')')
-            else if ($node/tei:div) then
+            else if ($node/tei:div/@xml:id) then
                 <ul>
                 {
                     toc:toc-passthru($model, $node, $current)

--- a/pages/departmenthistory/buildings/index.html
+++ b/pages/departmenthistory/buildings/index.html
@@ -34,8 +34,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/diplomatic-couriers.html
+++ b/pages/departmenthistory/diplomatic-couriers.html
@@ -316,7 +316,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history">Short History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/index.html
+++ b/pages/departmenthistory/index.html
@@ -62,8 +62,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/index.html
+++ b/pages/departmenthistory/index.html
@@ -21,9 +21,9 @@
                     <p>Since its creation in 1789, the Department of State has carried out a series
                         of reorganizations and has created new offices and bureaus to deal with new
                         diplomatic challenges.</p>
-                    <p>This portion of our website contains <a
-                            href="$app/departmenthistory/short-history">a short history of the
-                            department</a>, <a href="$app/departmenthistory/people/secretaries"
+                    <p>This portion of our website contains 
+                        <a href="$app/departmenthistory/timeline">an Administrative Timeline of the
+                            Department of State</a>, <a href="$app/departmenthistory/people/secretaries"
                             >biographies of the Secretaries of State</a>, a database of <a
                             href="$app/departmenthistory/people/principals-chiefs">Principal
                             Officers and Chiefs of Mission</a>, and a history of <a

--- a/pages/departmenthistory/people/by-name/index.html
+++ b/pages/departmenthistory/people/by-name/index.html
@@ -38,8 +38,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/by-name/letter.html
+++ b/pages/departmenthistory/people/by-name/letter.html
@@ -41,8 +41,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/by-year/index.html
+++ b/pages/departmenthistory/people/by-year/index.html
@@ -38,8 +38,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/by-year/year.html
+++ b/pages/departmenthistory/people/by-year/year.html
@@ -41,8 +41,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/chiefsofmission/by-role-or-country-id.html
+++ b/pages/departmenthistory/people/chiefsofmission/by-role-or-country-id.html
@@ -39,8 +39,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/chiefsofmission/countries-list.html
+++ b/pages/departmenthistory/people/chiefsofmission/countries-list.html
@@ -41,8 +41,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/chiefsofmission/index.html
+++ b/pages/departmenthistory/people/chiefsofmission/index.html
@@ -45,8 +45,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/chiefsofmission/international-organizations-list.html
+++ b/pages/departmenthistory/people/chiefsofmission/international-organizations-list.html
@@ -41,8 +41,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/index.html
+++ b/pages/departmenthistory/people/index.html
@@ -50,8 +50,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/person.html
+++ b/pages/departmenthistory/people/person.html
@@ -58,8 +58,8 @@
                         </div>
                         <ul class="hsg-list-group">
                             <li class="hsg-list-group-item">
-                                <a href="$app/departmenthistory/short-history" class="highlight"
-                                    >Short History</a>
+                                <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                    Department of State</a>
                             </li>
                             <li class="hsg-list-group-item">
                                 <a href="$app/departmenthistory/buildings">Buildings of the
@@ -123,8 +123,8 @@
                         </div>
                         <ul class="hsg-list-group">
                             <li class="hsg-list-group-item">
-                                <a href="$app/departmenthistory/short-history" class="highlight"
-                                    >Short History</a>
+                                <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                    Department of State</a>
                             </li>
                             <li class="hsg-list-group-item">
                                 <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/principalofficers/by-role-id.html
+++ b/pages/departmenthistory/people/principalofficers/by-role-id.html
@@ -39,8 +39,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/principalofficers/index.html
+++ b/pages/departmenthistory/people/principalofficers/index.html
@@ -36,8 +36,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/principals-chiefs.html
+++ b/pages/departmenthistory/people/principals-chiefs.html
@@ -294,8 +294,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/people/secretaries.html
+++ b/pages/departmenthistory/people/secretaries.html
@@ -35,8 +35,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/short-history/index.html
+++ b/pages/departmenthistory/short-history/index.html
@@ -24,6 +24,26 @@
                 <div id="content-inner">
                     <div id="content-container" data-template="app:fix-links">
                         <h1>A Short History of the Department of State</h1>
+                        <div class="alert alert-danger" role="alert">
+                            <h2>NOTE TO READERS</h2>
+                            <p>This publication, “A Short History of the Department of State,” has
+                                been retired. The text remains online for reference purposes, but it
+                                is no longer being maintained or expanded.</p> 
+                            <p>Why retire “A Short History”? In mid-2016 the Office of the Historian
+                                completed a review of its online offerings and concluded that
+                                extensive resources would be needed to revise and expand this
+                                publication to meet the Office’s standards for accuracy and
+                                comprehensiveness. At the same time, the events described in the “A
+                                Short History” essays are amply covered by numerous respected
+                                secondary sources. Rather than duplicate these efforts, the Office
+                                of the Historian has decided to focus its resources on areas where
+                                it is uniquely suited to make a contribution, such as coverage of <a
+                                    href="/departmenthistory/timeline">the Department of State’s
+                                    institutional history</a>. In keeping with the publication’s new
+                                status, it can now be found under “More Resources” in the site-wide
+                                menu.</p>
+                            <p style="text-align: right; font-style: italic">Notice posted on April 8, 2018.</p>
+                        </div>
                         <div class="toc" data-template="toc:table-of-contents"/>
                     </div>
                 </div>
@@ -35,8 +55,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/short-history/section.html
+++ b/pages/departmenthistory/short-history/section.html
@@ -40,6 +40,11 @@
             <div class="hsg-width-main">
                 <div id="content-inner">
                     <div id="content-container" data-template="app:fix-links">
+                        <div class="alert alert-danger" role="alert">
+                            <strong>NOTE TO READERS</strong>
+                            <br/> “A Short History of the Department of State” has been
+                            retired and is no longer maintained. For more information, please see <a
+                                href="$app/timeline">the full notice</a>.</div>
                         <div class="content" data-template="pages:view"/>
                     </div>
                 </div>

--- a/pages/departmenthistory/timeline/index.html
+++ b/pages/departmenthistory/timeline/index.html
@@ -22,7 +22,7 @@
             <div class="hsg-width-two-thirds">
                 <div id="content-inner">
                     <div id="content-container">
-                        <h1>Introduction</h1>
+                        <h1>Administrative Timeline of the Department of State</h1>
                         <p>This annotated timeline encompasses principal events concerning
                             Department of State administration from 1789 through 2017, focusing on
                             the establishment of new offices and changes in organization. Research

--- a/pages/departmenthistory/timeline/index.html
+++ b/pages/departmenthistory/timeline/index.html
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<div data-template="templates:surround" data-template-with="templates/site.html"
+    data-template-at="content">
+    <div data-template="pages:load">
+        <div id="static-title" class="hidden">Administrative Timeline - Department History</div>
+        <div class="row">
+            <div class="hsg-breadcrumb-wrapper">
+                <ol class="breadcrumb" data-template="app:fix-links">
+                    <li>
+                        <a href="$app">Home</a>
+                    </li>
+                    <li>
+                        <a href="$app/departmenthistory">Department History</a>
+                    </li>
+                    <li>
+                        <a href="$app/departmenthistory/timeline">Administrative Timeline</a>
+                    </li>
+                </ol>
+            </div>
+        </div>
+        <div class="row">
+            <div class="hsg-width-two-thirds">
+                <div id="content-inner">
+                    <div id="content-container" data-template="app:fix-links">
+                        <h1>Administrative Timeline of the Department of State</h1>
+                        <div data-template="toc:table-of-contents"/>
+                    </div>
+                </div>
+            </div>
+            <aside class="hsg-width-one-third">
+                <div id="sections" class="hsg-panel" data-template="app:fix-links">
+                    <div class="hsg-panel-heading">
+                        <h2 class="hsg-sidebar-title">Department History</h2>
+                    </div>
+                    <ul class="hsg-list-group">
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline" class="highlight"
+                                >Administrative Timeline</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/short-history">Short History</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/buildings">Buildings of the
+                                Department</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/people">People</a>
+                            <ul>
+                                <li class="hsg-list-group-item">
+                                    <a href="$app/departmenthistory/people/secretaries">Biographies
+                                        of the Secretaries of State</a>
+                                </li>
+                                <li class="hsg-list-group-item">
+                                    <a href="$app/departmenthistory/people/principals-chiefs"
+                                        >Principal Officers and Chiefs of Mission</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/travels">Travels</a>
+                            <ul>
+                                <li class="hsg-list-group-item">
+                                    <a href="$app/departmenthistory/travels/secretary">Travels of
+                                        the Secretary</a>
+                                </li>
+                                <li class="hsg-list-group-item">
+                                    <a href="$app/departmenthistory/travels/president">Travels of
+                                        the President</a>
+                                </li>
+                            </ul>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/visits">Visits by Foreign Leaders</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/wwi">World War I and the Department</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/diplomatic-couriers">U.S. Diplomatic
+                                Couriers</a>
+                        </li>
+                    </ul>
+                </div>
+            </aside>
+        </div>
+    </div>
+</div>

--- a/pages/departmenthistory/timeline/index.html
+++ b/pages/departmenthistory/timeline/index.html
@@ -21,64 +21,68 @@
         <div class="row">
             <div class="hsg-width-two-thirds">
                 <div id="content-inner">
-                    <div id="content-container" data-template="app:fix-links">
-                        <h1>Administrative Timeline of the Department of State</h1>
-                        <div data-template="toc:table-of-contents"/>
+                    <div id="content-container">
+                        <h1>Introduction</h1>
+                        <p>This annotated timeline encompasses principal events concerning
+                            Department of State administration from 1789 through 2017, focusing on
+                            the establishment of new offices and changes in organization. Research
+                            Historian Evan Duncan compiled this timeline beginning in 2006. Research
+                            Historian Thomas Faith edited the document for publication. The events
+                            and annotations are derived from a variety of public documents including
+                            the <em>Federal Register</em>, <em>U.S. Statutes at Large</em>,
+                            Executive Orders, Departmental Orders, and Department of State
+                            periodicals such as the <em>Department of State Bulletin</em> and
+                                <em>State Magazine</em>. We invite questions and comments about this
+                            resource at <a href="mailto:history@state.gov"
+                            >history@state.gov</a>.</p>
+                        <div class="tei-closer">Last updated, February 27, 2018.</div>
                     </div>
                 </div>
             </div>
             <aside class="hsg-width-one-third">
-                <div id="sections" class="hsg-panel" data-template="app:fix-links">
+                <div class="hsg-panel" data-template="app:fix-links">
                     <div class="hsg-panel-heading">
-                        <h2 class="hsg-sidebar-title">Department History</h2>
+                        <h2 class="hsg-sidebar-title">Periods</h2>
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/timeline" class="highlight"
-                                >Administrative Timeline</a>
+                            <a href="$app/departmenthistory/timeline/1789-1899">1789–1899</a>
                         </li>
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history">Short History</a>
+                            <a href="$app/departmenthistory/timeline/1900-1909">1900–1909</a>
                         </li>
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/buildings">Buildings of the
-                                Department</a>
+                            <a href="$app/departmenthistory/timeline/1910-1919">1910–1919</a>
                         </li>
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/people">People</a>
-                            <ul>
-                                <li class="hsg-list-group-item">
-                                    <a href="$app/departmenthistory/people/secretaries">Biographies
-                                        of the Secretaries of State</a>
-                                </li>
-                                <li class="hsg-list-group-item">
-                                    <a href="$app/departmenthistory/people/principals-chiefs"
-                                        >Principal Officers and Chiefs of Mission</a>
-                                </li>
-                            </ul>
+                            <a href="$app/departmenthistory/timeline/1920-1929">1920–1929</a>
                         </li>
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/travels">Travels</a>
-                            <ul>
-                                <li class="hsg-list-group-item">
-                                    <a href="$app/departmenthistory/travels/secretary">Travels of
-                                        the Secretary</a>
-                                </li>
-                                <li class="hsg-list-group-item">
-                                    <a href="$app/departmenthistory/travels/president">Travels of
-                                        the President</a>
-                                </li>
-                            </ul>
+                            <a href="$app/departmenthistory/timeline/1930-1939">1930–1939</a>
                         </li>
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/visits">Visits by Foreign Leaders</a>
+                            <a href="$app/departmenthistory/timeline/1940-1949">1940–1949</a>
                         </li>
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/wwi">World War I and the Department</a>
+                            <a href="$app/departmenthistory/timeline/1950-1959">1950–1959</a>
                         </li>
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/diplomatic-couriers">U.S. Diplomatic
-                                Couriers</a>
+                            <a href="$app/departmenthistory/timeline/1960-1969">1960–1969</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1970-1979">1970–1979</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1980-1989">1980–1989</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1990-1999">1990–1999</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/2000-2009">2000–2009</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/2010-2019">2010–present</a>
                         </li>
                     </ul>
                 </div>

--- a/pages/departmenthistory/timeline/index.html
+++ b/pages/departmenthistory/timeline/index.html
@@ -24,17 +24,20 @@
                     <div id="content-container">
                         <h1>Administrative Timeline of the Department of State</h1>
                         <p>This annotated timeline encompasses principal events concerning
-                            Department of State administration from 1789 through 2017, focusing on
-                            the establishment of new offices and changes in organization. Research
-                            Historian Evan Duncan compiled this timeline beginning in 2006. Research
-                            Historian Thomas Faith edited the document for publication. The events
-                            and annotations are derived from a variety of public documents including
-                            the <em>Federal Register</em>, <em>U.S. Statutes at Large</em>,
-                            Executive Orders, Departmental Orders, and Department of State
-                            periodicals such as the <em>Department of State Bulletin</em> and
-                                <em>State Magazine</em>. We invite questions and comments about this
-                            resource at <a href="mailto:history@state.gov"
-                            >history@state.gov</a>.</p>
+                            Department of State administration from 1789 through the most recent
+                            update noted below, focusing on the establishment of new offices and
+                            changes in organization. Research Historian Evan Duncan compiled this
+                            timeline beginning in 2006. Research Historian Thomas Faith edited the
+                            document for publication. The events and annotations are derived from a
+                            variety of public documents including the <em>Federal Register</em>,
+                                <em>U.S. Statutes at Large</em>, Executive Orders, Departmental
+                            Orders, and Department of State periodicals such as the <em>Department
+                                of State Bulletin</em> and <em>State Magazine</em>. We invite
+                            questions and comments about this resource at <a
+                                href="mailto:history@state.gov">history@state.gov</a>.</p>
+                        <p>Webpages of the Administrative Timeline of the Department of State are
+                            not yet searchable with the website's search engine, and we apologize
+                            for the inconvenience.</p>
                         <div class="tei-closer">Last updated, February 27, 2018.</div>
                     </div>
                 </div>

--- a/pages/departmenthistory/timeline/section.html
+++ b/pages/departmenthistory/timeline/section.html
@@ -16,6 +16,7 @@
                     <li>
                         <a href="$app/departmenthistory/timeline">Administrative Timeline</a>
                     </li>
+                    <li data-template="pages:deep-section-breadcrumbs"/>
                 </ol>
             </div>
         </div>
@@ -43,9 +44,53 @@
                 </div>
             </div>
             <!-- TOC Sidebar -->
-            <aside class="hsg-width-sidebar" data-template="app:fix-links">
-                <div data-template="toc:table-of-contents-sidebar" data-template-heading="false"
-                    data-template-highlight="true"/>
+            <aside class="hsg-width-one-third">
+                <div class="hsg-panel" data-template="app:fix-links">
+                    <div class="hsg-panel-heading">
+                        <h2 class="hsg-sidebar-title">Periods</h2>
+                    </div>
+                    <ul class="hsg-list-group">
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1789-1899">1789–1899</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1900-1909">1900–1909</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1910-1919">1910–1919</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1920-1929">1920–1929</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1930-1939">1930–1939</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1940-1949">1940–1949</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1950-1959">1950–1959</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1960-1969">1960–1969</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1970-1979">1970–1979</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1980-1989">1980–1989</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/1990-1999">1990–1999</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/2000-2009">2000–2009</a>
+                        </li>
+                        <li class="hsg-list-group-item">
+                            <a href="$app/departmenthistory/timeline/2010-2019">2010–present</a>
+                        </li>
+                    </ul>
+                </div>
             </aside>
         </div>
     </div>

--- a/pages/departmenthistory/timeline/section.html
+++ b/pages/departmenthistory/timeline/section.html
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<div data-template="templates:surround" data-template-with="templates/site.html"
+    data-template-at="content">
+    <div data-template="pages:load">
+        <div id="static-title" class="hidden"><span data-template="pages:navigation-title"/> 
+            - Department History</div>
+        <div class="row">
+            <div class="hsg-breadcrumb-wrapper">
+                <ol class="breadcrumb" data-template="app:fix-links">
+                    <li>
+                        <a href="$app">Home</a>
+                    </li>
+                    <li>
+                        <a href="$app/departmenthistory">Department History</a>
+                    </li>
+                    <li>
+                        <a href="$app/departmenthistory/timeline">Administrative Timeline</a>
+                    </li>
+                </ol>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="hsg-navigation-wrapper">
+                <h2 class="hsg-navigation-title" id="navigation-title"
+                    data-template="pages:navigation-title"/>
+            </div>
+        </div>
+        <div class="row" data-template="pages:navigation">
+            <a data-template="pages:navigation-link" data-template-direction="previous"
+                class="page-nav nav-prev">
+                <i class="glyphicon glyphicon-chevron-left"/>
+            </a>
+            <a data-template="pages:navigation-link" data-template-direction="next"
+                class="page-nav nav-next">
+                <i class="glyphicon glyphicon-chevron-right"/>
+            </a>
+            <div class="hsg-width-main">
+                <div id="content-inner">
+                    <div id="content-container" data-template="app:fix-links">
+                        <div class="content" data-template="pages:view"/>
+                    </div>
+                </div>
+            </div>
+            <!-- TOC Sidebar -->
+            <aside class="hsg-width-sidebar" data-template="app:fix-links">
+                <div data-template="toc:table-of-contents-sidebar" data-template-heading="false"
+                    data-template-highlight="true"/>
+            </aside>
+        </div>
+    </div>
+</div>

--- a/pages/departmenthistory/travels/index.html
+++ b/pages/departmenthistory/travels/index.html
@@ -40,8 +40,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/travels/president/index.html
+++ b/pages/departmenthistory/travels/president/index.html
@@ -44,8 +44,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/travels/president/person-or-country.html
+++ b/pages/departmenthistory/travels/president/person-or-country.html
@@ -40,8 +40,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/travels/secretary/index.html
+++ b/pages/departmenthistory/travels/secretary/index.html
@@ -44,8 +44,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/travels/secretary/person-or-country.html
+++ b/pages/departmenthistory/travels/secretary/person-or-country.html
@@ -40,8 +40,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/visits/country-or-year.html
+++ b/pages/departmenthistory/visits/country-or-year.html
@@ -37,8 +37,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/visits/index.html
+++ b/pages/departmenthistory/visits/index.html
@@ -39,8 +39,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/departmenthistory/wwi.html
+++ b/pages/departmenthistory/wwi.html
@@ -105,8 +105,8 @@
                     </div>
                     <ul class="hsg-list-group">
                         <li class="hsg-list-group-item">
-                            <a href="$app/departmenthistory/short-history" class="highlight">Short
-                                History</a>
+                            <a href="$app/departmenthistory/timeline">Administrative Timeline of the
+                                Department of State</a>
                         </li>
                         <li class="hsg-list-group-item">
                             <a href="$app/departmenthistory/buildings">Buildings of the

--- a/pages/milestones/index.html
+++ b/pages/milestones/index.html
@@ -24,18 +24,22 @@
                         <p>This publication, “Milestones in the History of U.S. Foreign Relations,”
                             has been retired. The text remains online for reference purposes, but it
                             is no longer being maintained or expanded.</p> 
-                        <p>Why retire “Milestones”? In mid-2016 the Office of the Historian completed a review of
-                            its online offerings and concluded that extensive resources would be
-                            needed to revise and expand this publication to meet the Office’s
-                            standards for accuracy and comprehensiveness. At the same time, the
-                            events described in the “Milestones” essays are amply covered by
-                            numerous respected secondary sources. Rather than duplicate these
+                        <p>Why retire “Milestones”? In mid-2016 the Office of the Historian
+                            completed a review of its online offerings and concluded that extensive
+                            resources would be needed to revise and expand this publication to meet
+                            the Office’s standards for accuracy and comprehensiveness. At the same
+                            time, the events described in the “Milestones” essays are amply covered
+                            by numerous respected secondary sources. Rather than duplicate these
                             efforts, the Office of the Historian has decided to focus its resources
                             on areas where it is uniquely suited to make a contribution, such as
-                            coverage of the Department of State’s institutional history. In keeping
-                            with the publication’s new status, it can now be found under “More
-                            Resources” in the site-wide menu.</p>
-                        <p style="text-align: right; font-style: italic">Notice posted on May 9, 2017.<br/> Updated June 1, 2017 to note that the review described was completed in mid-2016.</p>
+                            coverage of <a href="/departmenthistory/timeline">the Department of
+                                State’s institutional history</a>. In keeping with the publication’s
+                            new status, it can now be found under “More Resources” in the site-wide
+                            menu.</p>
+                        <p style="text-align: right; font-style: italic">Notice posted on May 9,
+                            2017.<br/> Updated June 1, 2017 to note that the review described was
+                            completed in mid-2016.<br/> Updated April 8, 2018 to link to the new
+                            Administrative Timeline of the Department of State.</p>
                     </div>
                     <p>“Milestones in the History of U.S. Foreign Relations” provides a general
                         overview of the history of U.S. engagement with the world through short


### PR DESCRIPTION
- This PR prepares history.state.gov for the addition of “Administrative Timeline of the Department of State,” a new @HistoryAtState publication compiled by Evan Duncan and edited/updated by @tomfaith, for a soft launch.
- “Soft launch” indicates that some functionality isn’t complete. While all pages should be navigable using the landing page, sidebar TOC, and previous/next functions, the site’s search engine hasn’t yet been updated to search this content. (An under-the-hood overhaul to the way we expose our collections to the search engine will be needed to make adding new collections possible.)
- Various sitewide menus that point to the timeline still need to be updated to add this new publication