### PR TITLE
Fix/frus issue 114

### DIFF
--- a/app/scss/_customized-bootstrap.scss
+++ b/app/scss/_customized-bootstrap.scss
@@ -16,29 +16,28 @@ $icon-font-path: "../fonts/";
   right: 15%;
 }
 
-.content img {
-  border: 1px solid $color-gray-light;
-  padding: 10px;
-  -webkit-border-radius: 1ex;
-  -moz-border-radius: 1ex;
-}
+.content {
 
-.content .labeled-list dt {
-  float: left;
-  display: inline;
-}
+  img {
+    border: 1px solid $color-gray-light;
+    padding: 10px;
+    -webkit-border-radius: 1ex;
+    -moz-border-radius: 1ex;
+  }
 
-.content .labeled-list dd {
-  margin-left: 3em;
-}
+  .labeled-list dt {
+    float: left;
+    display: inline;
+  }
 
-.content .listHead {
-  font-weight: bold;
-}
+  .labeled-list dd {
+    margin-left: 2em;
+  }
 
-.content .listHead + .list li {
-  margin-left: 2em;
-  font-size: 85%;
+  .listHead + .list li {
+    margin-left: 2em;
+    font-size: inherit;
+  }
 }
 
 /* Navbar ------------- */

--- a/app/scss/_tei.scss
+++ b/app/scss/_tei.scss
@@ -77,3 +77,20 @@
     }
   }
 }
+
+// frus.odd cssClasses for web output:
+.hsg-nested-list {
+  padding-left: 0;
+  list-style-type: inherit;
+  font-size: inherit;
+}
+
+.hsg-list-default {
+  list-style-type: none;
+  padding-left: 0;
+  font-size: inherit;
+}
+
+.hsg-list-disc {
+  list-style-type: disc;
+}

--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="http://history.state.gov/ns/site/hsg"
-    abbrev="hsg-shell" version="0.3" spec="1.0">
+    abbrev="hsg-shell" version="1.0.0" spec="1.0">
     <title>history.state.gov 3.0 shell</title>
     <dependency package="http://exist-db.org/apps/shared"/>
     <dependency package="http://www.tei-c.org/tei-simple"/>

--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <package xmlns="http://expath.org/ns/pkg" name="http://history.state.gov/ns/site/hsg"
-    abbrev="hsg-shell" version="1.0.0" spec="1.0">
+    abbrev="hsg-shell" version="1.0.1" spec="1.0">
     <title>history.state.gov 3.0 shell</title>
     <dependency package="http://exist-db.org/apps/shared"/>
     <dependency package="http://www.tei-c.org/tei-simple"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hsg-shell",
-  "version": "0.2.1",
+  "version": "1.0.0",
   "description": "## Setup",
   "main": "gulpfile.js",
   "dependencies": {},
@@ -31,6 +31,7 @@
     "url": "git+https://github.com/HistoryAtState/hsg-shell.git"
   },
   "author": "eXistSolutions",
+  "license": "UNLICENSED",
   "bugs": {
     "url": "https://github.com/HistoryAtState/hsg-shell/issues"
   },

--- a/resources/odd/compiled/frus.fo.css
+++ b/resources/odd/compiled/frus.fo.css
@@ -30,3 +30,14 @@
     keep-with-previous.within-page: always;
     space-after: 1em;
 }
+
+.hsg-list-default {
+    list-style-type: none;
+    padding-left: 0;
+    margin-left: 1em;
+    font-size: inherit;
+}
+
+.hsg-list-disc {
+    list-style-type: disc;
+}

--- a/resources/odd/source/frus.odd
+++ b/resources/odd/source/frus.odd
@@ -173,24 +173,21 @@
                         <model behaviour="heading" cssClass="listHead">
                             <param name="content">head/node()</param>
                             <param name="level">4</param>
+                            <desc>Headline for lists, level 4 will transform to html:h4 element</desc>
                         </model>
-                        <model behaviour="list" cssClass="list">
+                        <model behaviour="list" cssClass="list hsg-list-default">
                             <param name="content">item</param>
-                            <outputRendition>list-style-type: none; text-indent: -1em; margin-left: 1em; padding-left: 0</outputRendition>
                         </model>
                     </modelSequence>
-                    <model predicate="@rend = 'bulleted'" behaviour="list">
+                    <model predicate="@rend = 'bulleted'" behaviour="list" cssClass="hsg-list-disc">
                         <param name="content">item</param>
-                        <outputRendition>list-style-type: disc;</outputRendition>
                     </model>
-                    <model predicate="@type = ('participants', 'to', 'from', 'subject')" behaviour="list">
+                    <model predicate="@type = ('participants', 'to', 'from', 'subject')" behaviour="list" cssClass="hsg-list-default">
                         <param name="content">item</param>
-                        <outputRendition>list-style-type: none;</outputRendition>
                     </model>
                     <model predicate="parent::list/@type = ('participants', 'to', 'from', 'subject')" behaviour="list">
                         <param name="content">item</param>
                         <desc>This is a nested list within a list-item</desc>
-                        <outputRendition>list-style-type: none; margin-top: 1em;</outputRendition>
                     </model>
                     <model predicate="label" behaviour="list" cssClass="labeled-list">
                         <param name="content">item</param>
@@ -302,9 +299,7 @@
                     <model predicate="@rend='smallfloatinline'" behaviour="block" cssClass="float-left figure-floated"/>
                     <model predicate="head or @rendition='simple:display'" behaviour="block"/>
                     <model behaviour="inline">
-                        <outputRendition>
-display: block;
-</outputRendition>
+                        <outputRendition>display: block;</outputRendition>
                     </model>
                 </elementSpec>
                 <elementSpec mode="change" ident="label"><!-- Silly rule to avoid class 'label' -->


### PR DESCRIPTION
**Fix styling for lists, sublists**
* delete obsolete odd styles, which were never applied anyway
* add descriptions
* remove output-renditions off odd and replace with css classes as a
hook to apply the styling scss for screen and frus.fo.css for PDF
* enhance scss nesting customized-bootstrap.scss
* remove obsolete listHead rule in scss
* align dd („labeled-list“ items) and li elements with same margin-left
value

**Update version to semver syntax**
* add license field to package.json to avoid warnings while running npm
scripts

![frus-issue-114](https://user-images.githubusercontent.com/1157669/60356406-276a4000-99d1-11e9-8afd-17747f96caf3.png)

* [https://history.state.gov/historicaldocuments/frus1961-63v20/d45](https://history.state.gov/historicaldocuments/frus1961-63v20/d45)
* [https://history.state.gov/historicaldocuments/frus1969-76v20/d10](https://history.state.gov/historicaldocuments/frus1969-76v20/d10)
* [https://history.state.gov/historicaldocuments/frus1964-68v29p2/d13](https://history.state.gov/historicaldocuments/frus1964-68v29p2/d13)