### PR TITLE
WIP: Fix FRUS odd rules #343

### DIFF
--- a/app/scss/_tei.scss
+++ b/app/scss/_tei.scss
@@ -94,3 +94,16 @@
 .hsg-list-disc {
   list-style-type: disc;
 }
+
+// Font-styles for 'tei:hi' elements
+// Override falsely set 'tei-hi1' classes which contain font-weight strong rule!
+.font {
+  &-italic {
+    font-style: italic;
+    font-weight: inherit !important;
+  }
+  &-smallcaps {
+    font-variant: small-caps;
+    font-weight: inherit !important;
+  }
+}

--- a/resources/odd/source/frus.odd
+++ b/resources/odd/source/frus.odd
@@ -128,16 +128,16 @@
                     <model predicate="@rend = 'strong'" behaviour="inline">
                         <outputRendition>font-weight: bold;</outputRendition>
                     </model>
-                    <model predicate="@rend = 'italic'" behaviour="inline">
+                    <model predicate="@rend = 'italic'" behaviour="inline" cssClass="font-italic">
                         <outputRendition>font-style: italic;</outputRendition>
                     </model>
-                    <model predicate="@rend = 'smallcaps'" behaviour="inline">
+                    <model predicate="@rend = 'smallcaps'" behaviour="inline" cssClass="font-smallcaps">
                         <outputRendition>font-variant: small-caps;</outputRendition>
                     </model>
-                    <model predicate="@rendition" behaviour="inline" useSourceRendition="true">
+                    <model predicate="@rendition" behaviour="inline" useSourceRendition="true" cssClass="font-italic">
                         <outputRendition>font-style: italic;</outputRendition>
                     </model>
-                    <model predicate="not(@rendition)" behaviour="inline">
+                    <model predicate="not(@rendition)" behaviour="inline" cssClass="font-italic">
                         <outputRendition>font-style: italic;</outputRendition>
                     </model>
                 </elementSpec>


### PR DESCRIPTION
1. Apply css override rules for 'hi' elements
* override ignored output renditions and falsely set 'tei-hi1' classes
which contain font-weight strong rule