### PR TITLE
fix(#343): Apply css override rules for 'hi' elements

### DIFF
--- a/expath-pkg.xml
+++ b/expath-pkg.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://expath.org/ns/pkg" name="http://history.state.gov/ns/site/hsg"
-    abbrev="hsg-shell" version="2.0.1" spec="1.0">
+<package xmlns="http://expath.org/ns/pkg" name="http://history.state.gov/ns/site/hsg" abbrev="hsg-shell" version="2.0.2" spec="1.0">
     <title>history.state.gov 3.0 shell</title>
     <dependency package="http://exist-db.org/apps/shared"/>
     <dependency package="http://www.tei-c.org/tei-simple"/>

--- a/resources/odd/compiled/frus.odd
+++ b/resources/odd/compiled/frus.odd
@@ -254,16 +254,16 @@ display: block;
                     <model predicate="@rend = 'strong'" behaviour="inline">
                         <outputRendition>font-weight: bold;</outputRendition>
                     </model>
-                    <model predicate="@rend = 'italic'" behaviour="inline">
+                    <model predicate="@rend = 'italic'" behaviour="inline" cssClass="font-italic">
                         <outputRendition>font-style: italic;</outputRendition>
                     </model>
-                    <model predicate="@rend = 'smallcaps'" behaviour="inline">
+                    <model predicate="@rend = 'smallcaps'" behaviour="inline" cssClass="font-smallcaps">
                         <outputRendition>font-variant: small-caps;</outputRendition>
                     </model>
-                    <model predicate="@rendition" behaviour="inline" useSourceRendition="true">
+                    <model predicate="@rendition" behaviour="inline" useSourceRendition="true" cssClass="font-italic">
                         <outputRendition>font-style: italic;</outputRendition>
                     </model>
-                    <model predicate="not(@rendition)" behaviour="inline">
+                    <model predicate="not(@rendition)" behaviour="inline" cssClass="font-italic">
                         <outputRendition>font-style: italic;</outputRendition>
                     </model>
                 </elementSpec><elementSpec mode="change" ident="imprimatur">


### PR DESCRIPTION
* override ignored output renditions and falsely set 'tei-hi1' classes
which contain font-weight strong rule