### PR TITLE
Fix/issue 278

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -48,10 +48,10 @@ else if ($exist:path eq "/" or (: remove after beta period :) ($exist:path eq ''
         <view>
             <forward url="{$exist:controller}/modules/view.xql"/>
         </view>
-		<error-handler>
-			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-			<forward url="{$exist:controller}/modules/view.xql"/>
-		</error-handler>
+        <error-handler>
+            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+            <forward url="{$exist:controller}/modules/view.xql"/>
+        </error-handler>
     </dispatch>
 
 (: strip trailing slash :)
@@ -104,10 +104,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                             <view>
                                                 <forward url="{$exist:controller}/modules/view.xql"/>
                                             </view>
-                                    		<error-handler>
-                                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                                    		</error-handler>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
                                         </dispatch>
                                 case "browse" return
                                     let $page := "historicaldocuments/pre-1861/serial-set/browse.html"
@@ -117,10 +117,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                             <view>
                                                 <forward url="{$exist:controller}/modules/view.xql"/>
                                             </view>
-                                    		<error-handler>
-                                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                                    		</error-handler>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
                                         </dispatch>
                                 default return
                                     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
@@ -132,10 +132,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                                 <add-parameter name="uri" value="{$exist:path}"/>
                                             </forward>
                                         </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
                                     </dispatch>
                         else
                             let $page := "historicaldocuments/pre-1861/serial-set/index.html"
@@ -145,10 +145,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                     <view>
                                         <forward url="{$exist:controller}/modules/view.xql"/>
                                     </view>
-                            		<error-handler>
-                            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                            			<forward url="{$exist:controller}/modules/view.xql"/>
-                            		</error-handler>
+                                    <error-handler>
+                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                    </error-handler>
                                 </dispatch>
                     else
                         let $page := "historicaldocuments/pre-1861/index.html"
@@ -158,10 +158,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                 <view>
                                     <forward url="{$exist:controller}/modules/view.xql"/>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                 case "frus-history" return
                     if ($fragments[2]) then
@@ -178,10 +178,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                                     <add-parameter name="document-id" value="{$document-id}"/>
                                                 </forward>
                                             </view>
-                                    		<error-handler>
-                                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                                    		</error-handler>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
                                         </dispatch>
                                 else
                                     let $page := "historicaldocuments/frus-history/documents/index.html"
@@ -191,10 +191,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                             <view>
                                                 <forward url="{$exist:controller}/modules/view.xql"/>
                                             </view>
-                                    		<error-handler>
-                                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                                    		</error-handler>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
                                         </dispatch>
                             case "events" return
                                 let $page := "historicaldocuments/frus-history/events/index.html"
@@ -204,10 +204,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                         <view>
                                             <forward url="{$exist:controller}/modules/view.xql"/>
                                         </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
                                     </dispatch>
                             case "research" return
                                 if ($fragments[3]) then
@@ -221,10 +221,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                                     <add-parameter name="article-id" value="{$article-id}"/>
                                                 </forward>
                                             </view>
-                                    		<error-handler>
-                                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                                    		</error-handler>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
                                         </dispatch>
                                 else
                                     let $page := "historicaldocuments/frus-history/research/index.html"
@@ -234,10 +234,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                             <view>
                                                 <forward url="{$exist:controller}/modules/view.xql"/>
                                             </view>
-                                    		<error-handler>
-                                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                                    		</error-handler>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
                                         </dispatch>
                             default return
                                 let $page := "historicaldocuments/frus-history/monograph-interior.html"
@@ -253,10 +253,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                                 <add-parameter name="requested-url" value="{local:get-url()}"/>
                                             </forward>
                                         </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
                                     </dispatch>
                     else
                         let $page := "historicaldocuments/frus-history/index.html"
@@ -269,10 +269,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                         <add-parameter name="document-id" value="frus-history"/>
                                     </forward>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                 case "quarterly-releases" return
                     if ($fragments[2]) then
@@ -296,10 +296,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                 <view>
                                     <forward url="{$exist:controller}/modules/view.xql"/>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                 case "guide-to-sources-on-vietnam-1969-1975" return
                     let $page := "historicaldocuments/vietnam-guide.html"
@@ -313,10 +313,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                     <add-parameter name="document-id" value="guide-to-sources-on-vietnam-1969-1975"/>
                                 </forward>
                             </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
+                            <error-handler>
+                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                <forward url="{$exist:controller}/modules/view.xql"/>
+                            </error-handler>
                         </dispatch>
                 default return
                     if (starts-with($fragments[1], "frus")) then
@@ -335,10 +335,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                             <add-parameter name="requested-url" value="{local:get-url()}"/>
                                         </forward>
                                     </view>
-                            		<error-handler>
-                            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                            			<forward url="{$exist:controller}/modules/view.xql"/>
-                            		</error-handler>
+                                    <error-handler>
+                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                    </error-handler>
                                 </dispatch>
                         else
                             let $page := "historicaldocuments/volume-landing.html"
@@ -352,10 +352,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                             <add-parameter name="document-id" value="{$document-id}"/>
                                         </forward>
                                     </view>
-                            		<error-handler>
-                            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                            			<forward url="{$exist:controller}/modules/view.xql"/>
-                            		</error-handler>
+                                    <error-handler>
+                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                    </error-handler>
                                 </dispatch>
                     else
                         if ($fragments[1] = ("about-frus", "citing-frus", "ebooks", "other-electronic-resources", "status-of-the-series")) then
@@ -366,10 +366,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                     <view>
                                         <forward url="{$exist:controller}/modules/view.xql"/>
                                     </view>
-                            		<error-handler>
-                            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                            			<forward url="{$exist:controller}/modules/view.xql"/>
-                            		</error-handler>
+                                    <error-handler>
+                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                    </error-handler>
                                 </dispatch>
                         else
                             let $page := "historicaldocuments/administrations.html"
@@ -382,10 +382,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                             <add-parameter name="administration-id" value="{$administration-id}"/>
                                         </forward>
                                     </view>
-                            		<error-handler>
-                            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                            			<forward url="{$exist:controller}/modules/view.xql"/>
-                            		</error-handler>
+                                    <error-handler>
+                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                    </error-handler>
                                 </dispatch>
         (: section landing page :)
         else (: if (not($fragments[1])) then :)
@@ -398,10 +398,10 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                             <add-parameter name="publication-id" value="historicaldocuments"/>
                         </forward>
                     </view>
-            		<error-handler>
-            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-            			<forward url="{$exist:controller}/modules/view.xql"/>
-            		</error-handler>
+                    <error-handler>
+                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                        <forward url="{$exist:controller}/modules/view.xql"/>
+                    </error-handler>
                 </dispatch>
 
 (: handle requests for countries section :)
@@ -418,10 +418,10 @@ else if (matches($exist:path, '^/countries/?')) then
                             <view>
                                 <forward url="{$exist:controller}/modules/view.xql"/>
                             </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
+                            <error-handler>
+                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                <forward url="{$exist:controller}/modules/view.xql"/>
+                            </error-handler>
                         </dispatch>
                 case "issues" return
                     if ($fragments[2]) then
@@ -436,10 +436,10 @@ else if (matches($exist:path, '^/countries/?')) then
                                         <add-parameter name="document-id" value="{$document-id}"/>
                                     </forward>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                     else
                         let $page := 'countries/issues/index.html'
@@ -449,10 +449,10 @@ else if (matches($exist:path, '^/countries/?')) then
                                 <view>
                                     <forward url="{$exist:controller}/modules/view.xql"/>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                 case "archives" return
                     if ($fragments[2]) then
@@ -467,10 +467,10 @@ else if (matches($exist:path, '^/countries/?')) then
                                             <add-parameter name="publication-id" value="archives"/>
                                         </forward>
                                     </view>
-                            		<error-handler>
-                            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                            			<forward url="{$exist:controller}/modules/view.xql"/>
-                            		</error-handler>
+                                    <error-handler>
+                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                    </error-handler>
                                 </dispatch>
                             default return
                                 let $document-id := $fragments[2]
@@ -484,10 +484,10 @@ else if (matches($exist:path, '^/countries/?')) then
                                                 <add-parameter name="document-id" value="{$document-id}"/>
                                             </forward>
                                         </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
                                     </dispatch>
                     else
                         let $page := 'countries/archives/index.html'
@@ -499,10 +499,10 @@ else if (matches($exist:path, '^/countries/?')) then
                                         <add-parameter name="publication-id" value="archives"/>
                                     </forward>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                 default return
                     let $page := 'countries/article.html'
@@ -516,10 +516,10 @@ else if (matches($exist:path, '^/countries/?')) then
                                     <add-parameter name="document-id" value="{$document-id}"/>
                                 </forward>
                             </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
+                            <error-handler>
+                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                <forward url="{$exist:controller}/modules/view.xql"/>
+                            </error-handler>
                         </dispatch>
         else
             let $page := 'countries/index.html'
@@ -531,10 +531,10 @@ else if (matches($exist:path, '^/countries/?')) then
                             <add-parameter name="publication-id" value="countries"/>
                         </forward>
                     </view>
-            		<error-handler>
-            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-            			<forward url="{$exist:controller}/modules/view.xql"/>
-            		</error-handler>
+                    <error-handler>
+                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                        <forward url="{$exist:controller}/modules/view.xql"/>
+                    </error-handler>
                 </dispatch>
 
 (: handle requests for departmenthistory section :)
@@ -894,10 +894,10 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                                 <add-parameter name="publication-id" value="travels-president"/>
                                             </forward>
                                         </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
                                     </dispatch>
                             else
                                 let $page := 'departmenthistory/travels/president/index.html'
@@ -909,10 +909,10 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                                 <add-parameter name="publication-id" value="travels-president"/>
                                             </forward>
                                         </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
                                     </dispatch>
                         case "secretary" return
                             if ($fragments[3]) then
@@ -927,10 +927,10 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                                 <add-parameter name="publication-id" value="travels-secretary"/>
                                             </forward>
                                         </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
                                     </dispatch>
                             else
                                 let $page := 'departmenthistory/travels/secretary/index.html'
@@ -957,10 +957,10 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                         <add-parameter name="uri" value="{$exist:path}"/>
                                     </forward>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                 else
                     let $page := 'departmenthistory/travels/index.html'
@@ -1049,10 +1049,10 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                     <add-parameter name="publication-id" value="{$publication-id}"/>
                                 </forward>
                             </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
+                            <error-handler>
+                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                <forward url="{$exist:controller}/modules/view.xql"/>
+                            </error-handler>
                         </dispatch>
             default return
                 let $page :=
@@ -1119,10 +1119,10 @@ else if (matches($exist:path, '^/about/?')) then
                                         <add-parameter name="section-id" value="{$section-id}"/>
                                     </forward>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                     else
                         let $page := "about/faq/index.html"
@@ -1139,10 +1139,10 @@ else if (matches($exist:path, '^/about/?')) then
                                         <add-parameter name="section-id" value="{$section-id}"/>
                                     </forward>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                 case "hac" return
                     if ($fragments[2]) then
@@ -1160,10 +1160,10 @@ else if (matches($exist:path, '^/about/?')) then
                                         <add-parameter name="section-id" value="{$section-id}"/>
                                     </forward>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                     else
                         let $page := "about/hac/index.html"
@@ -1178,10 +1178,10 @@ else if (matches($exist:path, '^/about/?')) then
                                         <add-parameter name="document-id" value="{$document-id}"/>
                                     </forward>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                 default return
                     let $page :=
@@ -1200,10 +1200,10 @@ else if (matches($exist:path, '^/about/?')) then
                                     <add-parameter name="uri" value="{$exist:path}"/>
                                 </forward>
                             </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
+                            <error-handler>
+                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                <forward url="{$exist:controller}/modules/view.xql"/>
+                            </error-handler>
                         </dispatch>
         else
             let $page := "about/index.html"
@@ -1215,10 +1215,10 @@ else if (matches($exist:path, '^/about/?')) then
                             <add-parameter name="publication-id" value="about"/>
                         </forward>
                     </view>
-            		<error-handler>
-            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-            			<forward url="{$exist:controller}/modules/view.xql"/>
-            		</error-handler>
+                    <error-handler>
+                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                        <forward url="{$exist:controller}/modules/view.xql"/>
+                    </error-handler>
                 </dispatch>
 
 (: handle requests for milestones section :)
@@ -1240,10 +1240,10 @@ else if (matches($exist:path, '^/milestones/?')) then
                                 <add-parameter name="section-id" value="{$section-id}"/>
                             </forward>
                         </view>
-                		<error-handler>
-                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                			<forward url="{$exist:controller}/modules/view.xql"/>
-                		</error-handler>
+                        <error-handler>
+                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                            <forward url="{$exist:controller}/modules/view.xql"/>
+                        </error-handler>
                     </dispatch>
             else
                 if ($fragments[1] = 'all') then
@@ -1256,10 +1256,10 @@ else if (matches($exist:path, '^/milestones/?')) then
                                     <add-parameter name="publication-id" value="milestones"/>
                                 </forward>
                             </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
+                            <error-handler>
+                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                <forward url="{$exist:controller}/modules/view.xql"/>
+                            </error-handler>
                         </dispatch>
                 else
                     let $chapter-id := $fragments[1]
@@ -1273,10 +1273,10 @@ else if (matches($exist:path, '^/milestones/?')) then
                                     <add-parameter name="document-id" value="{$chapter-id}"/>
                                 </forward>
                             </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
+                            <error-handler>
+                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                <forward url="{$exist:controller}/modules/view.xql"/>
+                            </error-handler>
                         </dispatch>
         else
             let $page := 'milestones/index.html'
@@ -1288,10 +1288,10 @@ else if (matches($exist:path, '^/milestones/?')) then
                             <add-parameter name="publication-id" value="milestones"/>
                         </forward>
                     </view>
-            		<error-handler>
-            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-            			<forward url="{$exist:controller}/modules/view.xql"/>
-            		</error-handler>
+                    <error-handler>
+                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                        <forward url="{$exist:controller}/modules/view.xql"/>
+                    </error-handler>
                 </dispatch>
 
 (: handle requests for conferences section :)
@@ -1314,10 +1314,10 @@ else if (matches($exist:path, '^/conferences/?')) then
                                 <add-parameter name="section-id" value="{$section-id}"/>
                             </forward>
                         </view>
-                		<error-handler>
-                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                			<forward url="{$exist:controller}/modules/view.xql"/>
-                		</error-handler>
+                        <error-handler>
+                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                            <forward url="{$exist:controller}/modules/view.xql"/>
+                        </error-handler>
                     </dispatch>
             else
                 let $page := 'conferences/conference/index.html'
@@ -1332,10 +1332,10 @@ else if (matches($exist:path, '^/conferences/?')) then
                                 <add-parameter name="document-id" value="{$document-id}"/>
                             </forward>
                         </view>
-                		<error-handler>
-                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                			<forward url="{$exist:controller}/modules/view.xql"/>
-                		</error-handler>
+                        <error-handler>
+                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                            <forward url="{$exist:controller}/modules/view.xql"/>
+                        </error-handler>
                     </dispatch>
         else
             let $page := 'conferences/index.html'
@@ -1348,10 +1348,10 @@ else if (matches($exist:path, '^/conferences/?')) then
                             <add-parameter name="publication-id" value="{$publication-id}"/>
                         </forward>
                     </view>
-            		<error-handler>
-            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-            			<forward url="{$exist:controller}/modules/view.xql"/>
-            		</error-handler>
+                    <error-handler>
+                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                        <forward url="{$exist:controller}/modules/view.xql"/>
+                    </error-handler>
                 </dispatch>
 
 (: handle requests for developer section :)
@@ -1370,10 +1370,10 @@ else if (matches($exist:path, '^/developer/?')) then
             <view>
                 <forward url="{$exist:controller}/modules/view.xql"/>
             </view>
-    		<error-handler>
-    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-    			<forward url="{$exist:controller}/modules/view.xql"/>
-    		</error-handler>
+            <error-handler>
+                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                <forward url="{$exist:controller}/modules/view.xql"/>
+            </error-handler>
         </dispatch>
 
 (: handle requests for open section :)
@@ -1403,10 +1403,10 @@ else if (matches($exist:path, '^/open/?')) then
             <view>
                 <forward url="{$exist:controller}/modules/view.xql"/>
             </view>,
-    		<error-handler>
-    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-    			<forward url="{$exist:controller}/modules/view.xql"/>
-    		</error-handler>
+            <error-handler>
+                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                <forward url="{$exist:controller}/modules/view.xql"/>
+            </error-handler>
             ) else ()}
         </dispatch>
 
@@ -1426,10 +1426,10 @@ else if (matches($exist:path, '^/tags/?')) then
                                     <add-parameter name="publication-id" value="tags"/>
                                 </forward>
                             </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
+                            <error-handler>
+                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                <forward url="{$exist:controller}/modules/view.xql"/>
+                            </error-handler>
                         </dispatch>
                 default return
                     let $page := "tags/browse.html"
@@ -1443,10 +1443,10 @@ else if (matches($exist:path, '^/tags/?')) then
                                     <add-parameter name="tag-id" value="{$tag-id}"/>
                                 </forward>
                             </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
+                            <error-handler>
+                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                <forward url="{$exist:controller}/modules/view.xql"/>
+                            </error-handler>
                         </dispatch>
         else
             let $page := "tags/index.html"
@@ -1458,10 +1458,10 @@ else if (matches($exist:path, '^/tags/?')) then
                             <add-parameter name="publication-id" value="tags"/>
                         </forward>
                     </view>
-            		<error-handler>
-            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-            			<forward url="{$exist:controller}/modules/view.xql"/>
-            		</error-handler>
+                    <error-handler>
+                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                        <forward url="{$exist:controller}/modules/view.xql"/>
+                    </error-handler>
                 </dispatch>
 
 (: handle requests for education section :)
@@ -1483,10 +1483,10 @@ else if (matches($exist:path, '^/education/?')) then
                                         <add-parameter name="document-id" value="{$document-id}"/>
                                     </forward>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                     else
                         let $page := "education/modules.html"
@@ -1496,10 +1496,10 @@ else if (matches($exist:path, '^/education/?')) then
                                 <view>
                                     <forward url="{$exist:controller}/modules/view.xql"/>
                                 </view>
-                        		<error-handler>
-                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                        		</error-handler>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
                             </dispatch>
                 default return
                     let $page := "error-page.html"
@@ -1512,10 +1512,10 @@ else if (matches($exist:path, '^/education/?')) then
                                     <set-attribute name="hsg-shell.errcode" value="404"/>
                                 </forward>
                             </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
+                            <error-handler>
+                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                <forward url="{$exist:controller}/modules/view.xql"/>
+                            </error-handler>
                         </dispatch>
         else
             let $page := "education/index.html"
@@ -1525,10 +1525,10 @@ else if (matches($exist:path, '^/education/?')) then
                     <view>
                         <forward url="{$exist:controller}/modules/view.xql"/>
                     </view>
-            		<error-handler>
-            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-            			<forward url="{$exist:controller}/modules/view.xql"/>
-            		</error-handler>
+                    <error-handler>
+                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                        <forward url="{$exist:controller}/modules/view.xql"/>
+                    </error-handler>
                 </dispatch>
 
 (: handle search requests :)
@@ -1567,10 +1567,10 @@ else if (matches($exist:path, '^/search/?')) then
                     <add-parameter name="suppress-sitewide-search-field" value="true"/>
                 </forward>
             </view>
-    		<error-handler>
-    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-    			<forward url="{$exist:controller}/modules/view.xql"/>
-    		</error-handler>
+            <error-handler>
+                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                <forward url="{$exist:controller}/modules/view.xql"/>
+            </error-handler>
         </dispatch>
 
 (: handle OPDS API requests :)
@@ -1610,8 +1610,8 @@ else
                 <add-parameter name="uri" value="{$exist:path}"/>
             </forward>
         </view>
-		<error-handler>
-			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-			<forward url="{$exist:controller}/modules/view.xql"/>
-		</error-handler>
+        <error-handler>
+            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+            <forward url="{$exist:controller}/modules/view.xql"/>
+        </error-handler>
     </dispatch>

--- a/controller.xql
+++ b/controller.xql
@@ -388,7 +388,7 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                                     </error-handler>
                                 </dispatch>
         (: section landing page :)
-        else (: if (not($fragments[1])) then :)
+        else if (ends-with($exist:path, '/historicaldocuments')) then
             let $page := 'historicaldocuments/index.html'
             return
                 <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
@@ -403,6 +403,20 @@ else if (matches($exist:path, '^/historicaldocuments/?')) then
                         <forward url="{$exist:controller}/modules/view.xql"/>
                     </error-handler>
                 </dispatch>
+        else (: anything else is an error:)
+            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                <forward url="{$exist:controller}/pages/error-page.html"/>
+                <view>
+                    <forward url="{$exist:controller}/modules/view.xql">
+                        <set-attribute name="hsg-shell.errcode" value="404"/>
+                        <add-parameter name="uri" value="{$exist:path}"/>
+                    </forward>
+                </view>
+                <error-handler>
+                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                    <forward url="{$exist:controller}/modules/view.xql"/>
+                </error-handler>
+            </dispatch>
 
 (: handle requests for countries section :)
 else if (matches($exist:path, '^/countries/?')) then
@@ -521,7 +535,7 @@ else if (matches($exist:path, '^/countries/?')) then
                                 <forward url="{$exist:controller}/modules/view.xql"/>
                             </error-handler>
                         </dispatch>
-        else
+        else if (ends-with($exist:path, '/countries')) then
             let $page := 'countries/index.html'
             return
                 <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
@@ -536,425 +550,39 @@ else if (matches($exist:path, '^/countries/?')) then
                         <forward url="{$exist:controller}/modules/view.xql"/>
                     </error-handler>
                 </dispatch>
+        else (: anything else is an error :)
+            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                <forward url="{$exist:controller}/pages/error-page.html"/>
+                <view>
+                    <forward url="{$exist:controller}/modules/view.xql">
+                        <set-attribute name="hsg-shell.errcode" value="404"/>
+                        <add-parameter name="uri" value="{$exist:path}"/>
+                    </forward>
+                </view>
+                <error-handler>
+                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                    <forward url="{$exist:controller}/modules/view.xql"/>
+                </error-handler>
+            </dispatch>
 
 (: handle requests for departmenthistory section :)
 else if (matches($exist:path, '^/departmenthistory/?')) then
     let $fragments := tokenize(substring-after($exist:path, '/departmenthistory/'), '/')[. ne '']
     return
-        switch ($fragments[1])
-            case "timeline" return
-                if ($fragments[2]) then
-                    let $page := 'departmenthistory/timeline/section.html'
-                    let $section-id := $fragments[2]
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="timeline"/>
-                                    <add-parameter name="document-id" value="timeline"/>
-                                    <add-parameter name="section-id" value="{$section-id}"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-                else
-                    let $page := 'departmenthistory/timeline/index.html'
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="timeline"/>
-                                    <add-parameter name="document-id" value="timeline"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-            case "short-history" return
-                if ($fragments[2]) then
-                    let $page := 'departmenthistory/short-history/section.html'
-                    let $section-id := $fragments[2]
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="short-history"/>
-                                    <add-parameter name="document-id" value="short-history"/>
-                                    <add-parameter name="section-id" value="{$section-id}"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-                else
-                    let $page := 'departmenthistory/short-history/index.html'
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="short-history"/>
-                                    <add-parameter name="document-id" value="short-history"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-            case "buildings" return
-                if ($fragments[2]) then
-                    let $page := 'departmenthistory/buildings/section.html'
-                    let $section-id := $fragments[2]
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="buildings"/>
-                                    <add-parameter name="document-id" value="buildings"/>
-                                    <add-parameter name="section-id" value="{$section-id}"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-                else
-                    let $page := 'departmenthistory/buildings/index.html'
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="buildings"/>
-                                    <add-parameter name="document-id" value="buildings"/>
-                                    <add-parameter name="section-id" value="intro"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-
-            case "people" return
-                if ($fragments[2]) then
-                    switch ($fragments[2])
-                        case "secretaries" return
-                            let $page := 'departmenthistory/people/secretaries.html'
-                            return
-                                <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                    <forward url="{$exist:controller}/pages/{$page}"/>
-                                    <view>
-                                        <forward url="{$exist:controller}/modules/view.xql">
-                                            <add-parameter name="publication-id" value="{$fragments[2]}"/>
-                                        </forward>
-                                    </view>
-                            		<error-handler>
-                            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                            			<forward url="{$exist:controller}/modules/view.xql"/>
-                            		</error-handler>
-                                </dispatch>
-                        case "principals-chiefs" return
-                            let $page := 'departmenthistory/people/principals-chiefs.html'
-                            return
-                                <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                    <forward url="{$exist:controller}/pages/{$page}"/>
-                                    <view>
-                                        <forward url="{$exist:controller}/modules/view.xql">
-                                            <add-parameter name="publication-id" value="{$fragments[2]}"/>
-                                        </forward>
-                                    </view>
-                            		<error-handler>
-                            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                            			<forward url="{$exist:controller}/modules/view.xql"/>
-                            		</error-handler>
-                                </dispatch>
-                        case "by-name" return
-                            if ($fragments[3]) then
-                                let $page := 'departmenthistory/people/by-name/letter.html'
-                                let $letter := $fragments[3]
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">
-                                                <add-parameter name="letter" value="{$letter}"/>
-                                                <add-parameter name="publication-id" value="people-by-alpha"/>
-                                            </forward>
-                                        </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
-                                    </dispatch>
-                            else
-                                let $page := 'departmenthistory/people/by-name/index.html'
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">
-                                                <add-parameter name="publication-id" value="people-by-alpha"/>
-                                            </forward>
-                                        </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
-                                    </dispatch>
-                        case "by-year" return
-                            if ($fragments[3]) then
-                                let $page := 'departmenthistory/people/by-year/year.html'
-                                let $year := $fragments[3]
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">
-                                                <add-parameter name="publication-id" value="people-by-year"/>
-                                                <add-parameter name="year" value="{$year}"/>
-                                            </forward>
-                                        </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
-                                    </dispatch>
-                            else
-                                let $page := 'departmenthistory/people/by-year/index.html'
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">                                                                                    <add-parameter name="publication-id" value="people-by-year"/>
-                                            </forward>
-                                        </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
-                                    </dispatch>
-                        case "principalofficers" return
-                            if ($fragments[3]) then
-                                let $page := 'departmenthistory/people/principalofficers/by-role-id.html'
-                                let $role-id := $fragments[3]
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">
-                                                <add-parameter name="role-id" value="{$role-id}"/>
-                                                <add-parameter name="publication-id" value="people-by-role"/>
-                                            </forward>
-                                        </view>
-                                        <error-handler>
-                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                            <forward url="{$exist:controller}/modules/view.xql"/>
-                                        </error-handler>
-                                    </dispatch>
-                            else
-                                let $page := 'departmenthistory/people/principalofficers/index.html'
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">
-                                                <add-parameter name="publication-id" value="people"/>
-                                            </forward>
-                                        </view>
-                                        <error-handler>
-                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                            <forward url="{$exist:controller}/modules/view.xql"/>
-                                        </error-handler>
-                                    </dispatch>
-                        case "chiefsofmission" return
-                            if ($fragments[3]) then
-                                switch ($fragments[3])
-                                    case "by-country" return
-                                        let $page := 'departmenthistory/people/chiefsofmission/countries-list.html'
-                                        return
-                                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                                <forward url="{$exist:controller}/pages/{$page}"/>
-                                                <view>
-                                                    <forward url="{$exist:controller}/modules/view.xql">
-                                                        <add-parameter name="publication-id" value="people"/>
-                                                    </forward>
-                                                </view>
-                                        		<error-handler>
-                                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                                        		</error-handler>
-                                            </dispatch>
-                                    case "by-organization" return
-                                        let $page := 'departmenthistory/people/chiefsofmission/international-organizations-list.html'
-                                        return
-                                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                                <forward url="{$exist:controller}/pages/{$page}"/>
-                                                <view>
-                                                    <forward url="{$exist:controller}/modules/view.xql">
-                                                        <add-parameter name="publication-id" value="people"/>
-                                                    </forward>
-                                                </view>
-                                        		<error-handler>
-                                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                                        		</error-handler>
-                                            </dispatch>
-                                    default return
-                                        let $page := 'departmenthistory/people/chiefsofmission/by-role-or-country-id.html'
-                                        let $role-or-country-id := $fragments[3]
-                                        return
-                                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                                <forward url="{$exist:controller}/pages/{$page}"/>
-                                                <view>
-                                                    <forward url="{$exist:controller}/modules/view.xql">
-                                                        <add-parameter name="role-or-country-id" value="{$role-or-country-id}"/>
-                                                        <add-parameter name="publication-id" value="people"/>
-                                                    </forward>
-                                                </view>
-                                        		<error-handler>
-                                        			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                        			<forward url="{$exist:controller}/modules/view.xql"/>
-                                        		</error-handler>
-                                            </dispatch>
-                            else
-                                let $page := 'departmenthistory/people/chiefsofmission/index.html'
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">
-                                                <add-parameter name="publication-id" value="people"/>
-                                            </forward>
-                                        </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
-                                    </dispatch>
-                        default return
-                            let $page := 'departmenthistory/people/person.html'
-                            let $person-id := $fragments[2]
-                            return
-                                <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                    <forward url="{$exist:controller}/pages/{$page}"/>
-                                    <view>
-                                        <forward url="{$exist:controller}/modules/view.xql">
-                                            <add-parameter name="person-id" value="{$person-id}"/>
-                                            <add-parameter name="document-id" value="{$person-id}"/>
-                                            <add-parameter name="publication-id" value="people"/>
-                                        </forward>
-                                    </view>
-                                    <error-handler>
-                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                        <forward url="{$exist:controller}/modules/view.xql"/>
-                                    </error-handler>
-                                </dispatch>
-                else
-                    let $page := 'departmenthistory/people/index.html'
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="people"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-            case "travels" return
-                if ($fragments[2]) then
-                    switch ($fragments[2])
-                        case "president" return
-                            if ($fragments[3]) then
-                                let $page := 'departmenthistory/travels/president/person-or-country.html'
-                                let $person-or-country-id := $fragments[3]
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">
-                                                <add-parameter name="person-or-country-id" value="{$person-or-country-id}"/>
-                                                <add-parameter name="publication-id" value="travels-president"/>
-                                            </forward>
-                                        </view>
-                                        <error-handler>
-                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                            <forward url="{$exist:controller}/modules/view.xql"/>
-                                        </error-handler>
-                                    </dispatch>
-                            else
-                                let $page := 'departmenthistory/travels/president/index.html'
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">
-                                                <add-parameter name="publication-id" value="travels-president"/>
-                                            </forward>
-                                        </view>
-                                        <error-handler>
-                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                            <forward url="{$exist:controller}/modules/view.xql"/>
-                                        </error-handler>
-                                    </dispatch>
-                        case "secretary" return
-                            if ($fragments[3]) then
-                                let $page := 'departmenthistory/travels/secretary/person-or-country.html'
-                                let $person-or-country-id := $fragments[3]
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">
-                                                <add-parameter name="person-or-country-id" value="{$person-or-country-id}"/>
-                                                <add-parameter name="publication-id" value="travels-secretary"/>
-                                            </forward>
-                                        </view>
-                                        <error-handler>
-                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                            <forward url="{$exist:controller}/modules/view.xql"/>
-                                        </error-handler>
-                                    </dispatch>
-                            else
-                                let $page := 'departmenthistory/travels/secretary/index.html'
-                                return
-                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                        <forward url="{$exist:controller}/pages/{$page}"/>
-                                        <view>
-                                            <forward url="{$exist:controller}/modules/view.xql">
-                                                <add-parameter name="publication-id" value="travels-secretary"/>
-                                            </forward>
-                                        </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
-                                    </dispatch>
-                        default return
+        if ($fragments[1]) then
+            switch ($fragments[1])
+                case "timeline" return
+                    if ($fragments[2]) then
+                        let $page := 'departmenthistory/timeline/section.html'
+                        let $section-id := $fragments[2]
+                        return
                             <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                                <forward url="{$exist:controller}/pages/error-page.html">
-                                </forward>
+                                <forward url="{$exist:controller}/pages/{$page}"/>
                                 <view>
                                     <forward url="{$exist:controller}/modules/view.xql">
-                                        <set-attribute name="hsg-shell.errcode" value="404"/>
-                                        <add-parameter name="uri" value="{$exist:path}"/>
+                                        <add-parameter name="publication-id" value="timeline"/>
+                                        <add-parameter name="document-id" value="timeline"/>
+                                        <add-parameter name="section-id" value="{$section-id}"/>
                                     </forward>
                                 </view>
                                 <error-handler>
@@ -962,91 +590,515 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                     <forward url="{$exist:controller}/modules/view.xql"/>
                                 </error-handler>
                             </dispatch>
-                else
-                    let $page := 'departmenthistory/travels/index.html'
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="travels-secretary"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-            case "visits" return
-                if ($fragments[2]) then
-                    let $page := 'departmenthistory/visits/country-or-year.html'
-                    let $country-or-year := $fragments[2]
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="visits"/>
-                                    <add-parameter name="country-or-year" value="{$country-or-year}"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-                else
-                    let $page := 'departmenthistory/visits/index.html'
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="visits"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-            case "diplomatic-couriers" return
-                if ($fragments[2]) then
-                    let $publication-id := 'diplomatic-couriers'
-                    let $film-ids := ("before-the-jet-age", "behind-the-iron-curtain", "into-moscow", "through-the-khyber-pass")
+                    else
+                        let $page := 'departmenthistory/timeline/index.html'
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="timeline"/>
+                                        <add-parameter name="document-id" value="timeline"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+                case "short-history" return
+                    if ($fragments[2]) then
+                        let $page := 'departmenthistory/short-history/section.html'
+                        let $section-id := $fragments[2]
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="short-history"/>
+                                        <add-parameter name="document-id" value="short-history"/>
+                                        <add-parameter name="section-id" value="{$section-id}"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+                    else
+                        let $page := 'departmenthistory/short-history/index.html'
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="short-history"/>
+                                        <add-parameter name="document-id" value="short-history"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+                case "buildings" return
+                    if ($fragments[2]) then
+                        let $page := 'departmenthistory/buildings/section.html'
+                        let $section-id := $fragments[2]
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="buildings"/>
+                                        <add-parameter name="document-id" value="buildings"/>
+                                        <add-parameter name="section-id" value="{$section-id}"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+                    else
+                        let $page := 'departmenthistory/buildings/index.html'
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="buildings"/>
+                                        <add-parameter name="document-id" value="buildings"/>
+                                        <add-parameter name="section-id" value="intro"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+
+                case "people" return
+                    if ($fragments[2]) then
+                        switch ($fragments[2])
+                            case "secretaries" return
+                                let $page := 'departmenthistory/people/secretaries.html'
+                                return
+                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                        <forward url="{$exist:controller}/pages/{$page}"/>
+                                        <view>
+                                            <forward url="{$exist:controller}/modules/view.xql">
+                                                <add-parameter name="publication-id" value="{$fragments[2]}"/>
+                                            </forward>
+                                        </view>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
+                                    </dispatch>
+                            case "principals-chiefs" return
+                                let $page := 'departmenthistory/people/principals-chiefs.html'
+                                return
+                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                        <forward url="{$exist:controller}/pages/{$page}"/>
+                                        <view>
+                                            <forward url="{$exist:controller}/modules/view.xql">
+                                                <add-parameter name="publication-id" value="{$fragments[2]}"/>
+                                            </forward>
+                                        </view>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
+                                    </dispatch>
+                            case "by-name" return
+                                if ($fragments[3]) then
+                                    let $page := 'departmenthistory/people/by-name/letter.html'
+                                    let $letter := $fragments[3]
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="letter" value="{$letter}"/>
+                                                    <add-parameter name="publication-id" value="people-by-alpha"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                                else
+                                    let $page := 'departmenthistory/people/by-name/index.html'
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="publication-id" value="people-by-alpha"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                            case "by-year" return
+                                if ($fragments[3]) then
+                                    let $page := 'departmenthistory/people/by-year/year.html'
+                                    let $year := $fragments[3]
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="publication-id" value="people-by-year"/>
+                                                    <add-parameter name="year" value="{$year}"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                                else
+                                    let $page := 'departmenthistory/people/by-year/index.html'
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="publication-id" value="people-by-year"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                            case "principalofficers" return
+                                if ($fragments[3]) then
+                                    let $page := 'departmenthistory/people/principalofficers/by-role-id.html'
+                                    let $role-id := $fragments[3]
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="role-id" value="{$role-id}"/>
+                                                    <add-parameter name="publication-id" value="people-by-role"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                                else
+                                    let $page := 'departmenthistory/people/principalofficers/index.html'
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="publication-id" value="people"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                            case "chiefsofmission" return
+                                if ($fragments[3]) then
+                                    switch ($fragments[3])
+                                        case "by-country" return
+                                            let $page := 'departmenthistory/people/chiefsofmission/countries-list.html'
+                                            return
+                                                <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                                    <forward url="{$exist:controller}/pages/{$page}"/>
+                                                    <view>
+                                                        <forward url="{$exist:controller}/modules/view.xql">
+                                                            <add-parameter name="publication-id" value="people"/>
+                                                        </forward>
+                                                    </view>
+                                                    <error-handler>
+                                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                                    </error-handler>
+                                                </dispatch>
+                                        case "by-organization" return
+                                            let $page := 'departmenthistory/people/chiefsofmission/international-organizations-list.html'
+                                            return
+                                                <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                                    <forward url="{$exist:controller}/pages/{$page}"/>
+                                                    <view>
+                                                        <forward url="{$exist:controller}/modules/view.xql">
+                                                            <add-parameter name="publication-id" value="people"/>
+                                                        </forward>
+                                                    </view>
+                                                    <error-handler>
+                                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                                    </error-handler>
+                                                </dispatch>
+                                        default return
+                                            let $page := 'departmenthistory/people/chiefsofmission/by-role-or-country-id.html'
+                                            let $role-or-country-id := $fragments[3]
+                                            return
+                                                <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                                    <forward url="{$exist:controller}/pages/{$page}"/>
+                                                    <view>
+                                                        <forward url="{$exist:controller}/modules/view.xql">
+                                                            <add-parameter name="role-or-country-id" value="{$role-or-country-id}"/>
+                                                            <add-parameter name="publication-id" value="people"/>
+                                                        </forward>
+                                                    </view>
+                                                    <error-handler>
+                                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                                    </error-handler>
+                                                </dispatch>
+                                else
+                                    let $page := 'departmenthistory/people/chiefsofmission/index.html'
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="publication-id" value="people"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                            default return
+                                let $page := 'departmenthistory/people/person.html'
+                                let $person-id := $fragments[2]
+                                return
+                                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                        <forward url="{$exist:controller}/pages/{$page}"/>
+                                        <view>
+                                            <forward url="{$exist:controller}/modules/view.xql">
+                                                <add-parameter name="person-id" value="{$person-id}"/>
+                                                <add-parameter name="document-id" value="{$person-id}"/>
+                                                <add-parameter name="publication-id" value="people"/>
+                                            </forward>
+                                        </view>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
+                                    </dispatch>
+                    else
+                        let $page := 'departmenthistory/people/index.html'
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="people"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+                case "travels" return
+                    if ($fragments[2]) then
+                        switch ($fragments[2])
+                            case "president" return
+                                if ($fragments[3]) then
+                                    let $page := 'departmenthistory/travels/president/person-or-country.html'
+                                    let $person-or-country-id := $fragments[3]
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="person-or-country-id" value="{$person-or-country-id}"/>
+                                                    <add-parameter name="publication-id" value="travels-president"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                                else
+                                    let $page := 'departmenthistory/travels/president/index.html'
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="publication-id" value="travels-president"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                            case "secretary" return
+                                if ($fragments[3]) then
+                                    let $page := 'departmenthistory/travels/secretary/person-or-country.html'
+                                    let $person-or-country-id := $fragments[3]
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="person-or-country-id" value="{$person-or-country-id}"/>
+                                                    <add-parameter name="publication-id" value="travels-secretary"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                                else
+                                    let $page := 'departmenthistory/travels/secretary/index.html'
+                                    return
+                                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                            <forward url="{$exist:controller}/pages/{$page}"/>
+                                            <view>
+                                                <forward url="{$exist:controller}/modules/view.xql">
+                                                    <add-parameter name="publication-id" value="travels-secretary"/>
+                                                </forward>
+                                            </view>
+                                            <error-handler>
+                                                <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                                <forward url="{$exist:controller}/modules/view.xql"/>
+                                            </error-handler>
+                                        </dispatch>
+                            default return
+                                <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                    <forward url="{$exist:controller}/pages/error-page.html">
+                                    </forward>
+                                    <view>
+                                        <forward url="{$exist:controller}/modules/view.xql">
+                                            <set-attribute name="hsg-shell.errcode" value="404"/>
+                                            <add-parameter name="uri" value="{$exist:path}"/>
+                                        </forward>
+                                    </view>
+                                    <error-handler>
+                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                    </error-handler>
+                                </dispatch>
+                    else
+                        let $page := 'departmenthistory/travels/index.html'
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="travels-secretary"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+                case "visits" return
+                    if ($fragments[2]) then
+                        let $page := 'departmenthistory/visits/country-or-year.html'
+                        let $country-or-year := $fragments[2]
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="visits"/>
+                                        <add-parameter name="country-or-year" value="{$country-or-year}"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+                    else
+                        let $page := 'departmenthistory/visits/index.html'
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="visits"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+                case "diplomatic-couriers" return
+                    if ($fragments[2]) then
+                        let $publication-id := 'diplomatic-couriers'
+                        let $film-ids := ("before-the-jet-age", "behind-the-iron-curtain", "into-moscow", "through-the-khyber-pass")
+                        let $page :=
+                            if ($fragments[2] = $film-ids) then
+                                'departmenthistory/diplomatic-couriers/' || $fragments[2] || '.html'
+                            else
+                                ()
+                        let $film-id :=
+                            if ($fragments[2] = $film-ids) then
+                                $fragments[2]
+                            else
+                                ()
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="{$publication-id}"/>
+                                        <add-parameter name="film-id" value="{$film-id}"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+                    else
+                        let $page := 'departmenthistory/diplomatic-couriers/index.html'
+                        let $publication-id := 'diplomatic-couriers'
+                        return
+                            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                                <forward url="{$exist:controller}/pages/{$page}"/>
+                                <view>
+                                    <forward url="{$exist:controller}/modules/view.xql">
+                                        <add-parameter name="publication-id" value="{$publication-id}"/>
+                                    </forward>
+                                </view>
+                                <error-handler>
+                                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                    <forward url="{$exist:controller}/modules/view.xql"/>
+                                </error-handler>
+                            </dispatch>
+                default return
                     let $page :=
-                        if ($fragments[2] = $film-ids) then 
-                            'departmenthistory/diplomatic-couriers/' || $fragments[2] || '.html' 
-                        else 
-                            ()
-                    let $film-id :=
-                        if ($fragments[2] = $film-ids) then 
-                            $fragments[2]
-                        else
-                            ()
+                        switch ($fragments[1])
+                            case "wwi" return 'departmenthistory/wwi.html'
+                            default return 'departmenthistory/index.html'
+                    let $link :=
+                        switch ($fragments[1])
+                            case "wwi" return 'wwi'
+                            default return 'departmenthistory'
                     return
                         <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
                             <forward url="{$exist:controller}/pages/{$page}"/>
                             <view>
                                 <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="{$publication-id}"/>
-                                    <add-parameter name="film-id" value="{$film-id}"/>
-                                </forward>
-                            </view>
-                    		<error-handler>
-                    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                    			<forward url="{$exist:controller}/modules/view.xql"/>
-                    		</error-handler>
-                        </dispatch>
-                else
-                    let $page := 'departmenthistory/diplomatic-couriers/index.html'
-                    let $publication-id := 'diplomatic-couriers'
-                    return
-                        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}"/>
-                            <view>
-                                <forward url="{$exist:controller}/modules/view.xql">
-                                    <add-parameter name="publication-id" value="{$publication-id}"/>
+                                    <add-parameter name="publication-id" value="{$link}"/>
                                 </forward>
                             </view>
                             <error-handler>
@@ -1054,47 +1106,20 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                 <forward url="{$exist:controller}/modules/view.xql"/>
                             </error-handler>
                         </dispatch>
-            default return
-                let $page :=
-                    switch ($fragments[1])
-                        case "wwi" return 'departmenthistory/wwi.html'
-                        default return 'departmenthistory/index.html'
-                let $link :=
-                    switch ($fragments[1])
-                        case "wwi" return 'wwi'
-                        default return 'departmenthistory'
-                return
-                    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                        <forward url="{$exist:controller}/pages/{$page}"/>
-                        <view>
-                            <forward url="{$exist:controller}/modules/view.xql">
-                                <add-parameter name="publication-id" value="{$link}"/>
-                            </forward>
-                        </view>
-                		<error-handler>
-                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                			<forward url="{$exist:controller}/modules/view.xql"/>
-                		</error-handler>
-                    </dispatch>
-
-(: handle requests for about section :)
-else if ($exist:path = '/about-the-beta') then
-    let $page := 'about-the-beta.html'
-    return
-        <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-            <forward url="{$exist:controller}/pages/{$page}">
-            </forward>
-            <view>
-                <forward url="{$exist:controller}/modules/view.xql">
-                    <set-attribute name="hsg-shell.errcode" value="404"/>
-                    <add-parameter name="uri" value="{$exist:path}"/>
-                </forward>
-            </view>
-    		<error-handler>
-    			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-    			<forward url="{$exist:controller}/modules/view.xql"/>
-    		</error-handler>
-        </dispatch>
+        else (: anything else is an error :)
+            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                <forward url="{$exist:controller}/pages/error-page.html"/>
+                <view>
+                    <forward url="{$exist:controller}/modules/view.xql">
+                        <set-attribute name="hsg-shell.errcode" value="404"/>
+                        <add-parameter name="uri" value="{$exist:path}"/>
+                    </forward>
+                </view>
+                <error-handler>
+                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                    <forward url="{$exist:controller}/modules/view.xql"/>
+                </error-handler>
+            </dispatch>
 
 (: handle requests for about section :)
 else if (matches($exist:path, '^/about/?')) then
@@ -1205,7 +1230,7 @@ else if (matches($exist:path, '^/about/?')) then
                                 <forward url="{$exist:controller}/modules/view.xql"/>
                             </error-handler>
                         </dispatch>
-        else
+        else if (ends-with($exist:path, '/about')) then
             let $page := "about/index.html"
             return
                 <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
@@ -1220,6 +1245,21 @@ else if (matches($exist:path, '^/about/?')) then
                         <forward url="{$exist:controller}/modules/view.xql"/>
                     </error-handler>
                 </dispatch>
+        else (: anything else is an error :)
+            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                <forward url="{$exist:controller}/pages/error-page.html"/>
+                <view>
+                    <forward url="{$exist:controller}/modules/view.xql">
+                        <set-attribute name="hsg-shell.errcode" value="404"/>
+                        <add-parameter name="uri" value="{$exist:path}"/>
+                    </forward>
+                </view>
+                <error-handler>
+                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                    <forward url="{$exist:controller}/modules/view.xql"/>
+                </error-handler>
+            </dispatch>
+
 
 (: handle requests for milestones section :)
 else if (matches($exist:path, '^/milestones/?')) then
@@ -1278,7 +1318,7 @@ else if (matches($exist:path, '^/milestones/?')) then
                                 <forward url="{$exist:controller}/modules/view.xql"/>
                             </error-handler>
                         </dispatch>
-        else
+        else if (ends-with($exist:path, '/milestones')) then
             let $page := 'milestones/index.html'
             return
                 <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
@@ -1293,6 +1333,20 @@ else if (matches($exist:path, '^/milestones/?')) then
                         <forward url="{$exist:controller}/modules/view.xql"/>
                     </error-handler>
                 </dispatch>
+        else (: anything else is an error :)
+            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                <forward url="{$exist:controller}/pages/error-page.html"/>
+                <view>
+                    <forward url="{$exist:controller}/modules/view.xql">
+                        <set-attribute name="hsg-shell.errcode" value="404"/>
+                        <add-parameter name="uri" value="{$exist:path}"/>
+                    </forward>
+                </view>
+                <error-handler>
+                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                    <forward url="{$exist:controller}/modules/view.xql"/>
+                </error-handler>
+            </dispatch>
 
 (: handle requests for conferences section :)
 else if (matches($exist:path, '^/conferences/?')) then
@@ -1337,7 +1391,7 @@ else if (matches($exist:path, '^/conferences/?')) then
                             <forward url="{$exist:controller}/modules/view.xql"/>
                         </error-handler>
                     </dispatch>
-        else
+        else if (ends-with($exist:path, '/conferences')) then
             let $page := 'conferences/index.html'
             let $publication-id := 'conferences'
             return
@@ -1353,6 +1407,20 @@ else if (matches($exist:path, '^/conferences/?')) then
                         <forward url="{$exist:controller}/modules/view.xql"/>
                     </error-handler>
                 </dispatch>
+        else (: anything else is an error :)
+            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                <forward url="{$exist:controller}/pages/error-page.html"/>
+                <view>
+                    <forward url="{$exist:controller}/modules/view.xql">
+                        <set-attribute name="hsg-shell.errcode" value="404"/>
+                        <add-parameter name="uri" value="{$exist:path}"/>
+                    </forward>
+                </view>
+                <error-handler>
+                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                    <forward url="{$exist:controller}/modules/view.xql"/>
+                </error-handler>
+            </dispatch>
 
 (: handle requests for developer section :)
 else if (matches($exist:path, '^/developer/?')) then
@@ -1448,7 +1516,7 @@ else if (matches($exist:path, '^/tags/?')) then
                                 <forward url="{$exist:controller}/modules/view.xql"/>
                             </error-handler>
                         </dispatch>
-        else
+        else if (ends-with($exist:path, '/tags')) then
             let $page := "tags/index.html"
             return
                 <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
@@ -1463,6 +1531,20 @@ else if (matches($exist:path, '^/tags/?')) then
                         <forward url="{$exist:controller}/modules/view.xql"/>
                     </error-handler>
                 </dispatch>
+        else (: anything else is an error :)
+            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                <forward url="{$exist:controller}/pages/error-page.html"/>
+                <view>
+                    <forward url="{$exist:controller}/modules/view.xql">
+                        <set-attribute name="hsg-shell.errcode" value="404"/>
+                        <add-parameter name="uri" value="{$exist:path}"/>
+                    </forward>
+                </view>
+                <error-handler>
+                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                    <forward url="{$exist:controller}/modules/view.xql"/>
+                </error-handler>
+            </dispatch>
 
 (: handle requests for education section :)
 else if (matches($exist:path, '^/education/?')) then
@@ -1516,7 +1598,7 @@ else if (matches($exist:path, '^/education/?')) then
                                 <forward url="{$exist:controller}/modules/view.xql"/>
                             </error-handler>
                         </dispatch>
-        else
+        else if (ends-with($exist:path, '/education')) then
             let $page := "education/index.html"
             return
                 <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
@@ -1529,6 +1611,20 @@ else if (matches($exist:path, '^/education/?')) then
                         <forward url="{$exist:controller}/modules/view.xql"/>
                     </error-handler>
                 </dispatch>
+        else (: anything else is an error :)
+            <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                <forward url="{$exist:controller}/pages/error-page.html"/>
+                <view>
+                    <forward url="{$exist:controller}/modules/view.xql">
+                        <set-attribute name="hsg-shell.errcode" value="404"/>
+                        <add-parameter name="uri" value="{$exist:path}"/>
+                    </forward>
+                </view>
+                <error-handler>
+                    <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                    <forward url="{$exist:controller}/modules/view.xql"/>
+                </error-handler>
+            </dispatch>
 
 (: handle search requests :)
 else if (matches($exist:path, '^/search/?')) then

--- a/controller.xql
+++ b/controller.xql
@@ -88,7 +88,7 @@ else if (ends-with($exist:resource, ".xql")) then
 (: handle requests for historicaldocuments section :)
 else if (matches($exist:path, '^/historicaldocuments/?')) then
     let $fragments := tokenize(substring-after($exist:path, '/historicaldocuments/'), '/')[. ne '']
-(:    let $log := console:log("hsg-shell controller.xql fragments: " || string-join(for $f at $n in $fragments return concat($n, ": ", $f), ', ')):)
+    (:let $log := util:log("info","hsg-shell controller.xql fragments: " || string-join(for $f at $n in $fragments return concat($n, ": ", $f), ', ')):)
     return
         if ($fragments[1]) then
             switch ($fragments[1])
@@ -760,10 +760,10 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                                 <add-parameter name="publication-id" value="people-by-role"/>
                                             </forward>
                                         </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
                                     </dispatch>
                             else
                                 let $page := 'departmenthistory/people/principalofficers/index.html'
@@ -775,10 +775,10 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                                 <add-parameter name="publication-id" value="people"/>
                                             </forward>
                                         </view>
-                                		<error-handler>
-                                			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                                			<forward url="{$exist:controller}/modules/view.xql"/>
-                                		</error-handler>
+                                        <error-handler>
+                                            <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                            <forward url="{$exist:controller}/modules/view.xql"/>
+                                        </error-handler>
                                     </dispatch>
                         case "chiefsofmission" return
                             if ($fragments[3]) then
@@ -858,10 +858,10 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                             <add-parameter name="publication-id" value="people"/>
                                         </forward>
                                     </view>
-                            		<error-handler>
-                            			<forward url="{$exist:controller}/pages/error-page.html" method="get"/>
-                            			<forward url="{$exist:controller}/modules/view.xql"/>
-                            		</error-handler>
+                                    <error-handler>
+                                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                                        <forward url="{$exist:controller}/modules/view.xql"/>
+                                    </error-handler>
                                 </dispatch>
                 else
                     let $page := 'departmenthistory/people/index.html'
@@ -1505,8 +1505,7 @@ else if (matches($exist:path, '^/education/?')) then
                     let $page := "error-page.html"
                     return
                         <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-                            <forward url="{$exist:controller}/pages/{$page}">
-        </forward>
+                            <forward url="{$exist:controller}/pages/{$page}"/>
                             <view>
                                 <forward url="{$exist:controller}/modules/view.xql">
                                     <set-attribute name="hsg-shell.errcode" value="404"/>


### PR DESCRIPTION
The nested page endpoints weren’t defining any mistyping after the
keyword, so the error was not caught nor handled by the controller.

* forward to the error page (within each nested page type case) for
every requested url that is not defined as an endpoint
* any extra character that is added to an url won’t fit the given
pattern and will be redirected to the 404 page

Fixes #278