### PR TITLE
fix(controller): Add endpoint for "departmenthistory" landing

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -1113,6 +1113,23 @@ else if (matches($exist:path, '^/departmenthistory/?')) then
                                 <forward url="{$exist:controller}/modules/view.xql"/>
                             </error-handler>
                         </dispatch>
+                        
+        else if (ends-with($exist:path, '/departmenthistory')) then
+            let $page := "departmenthistory/index.html"
+            return
+                <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+                    <forward url="{$exist:controller}/pages/{$page}"/>
+                    <view>
+                        <forward url="{$exist:controller}/modules/view.xql">
+                            <add-parameter name="publication-id" value="departmenthistory"/>
+                        </forward>
+                    </view>
+                    <error-handler>
+                        <forward url="{$exist:controller}/pages/error-page.html" method="get"/>
+                        <forward url="{$exist:controller}/modules/view.xql"/>
+                    </error-handler>
+                </dispatch>
+
         else (: anything else is an error :)
             <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
                 <forward url="{$exist:controller}/pages/error-page.html"/>


### PR DESCRIPTION
With the latest fixes to the web tests I discovered that the endpoint for "departmenthistory/" was not working as in my local tests before, so I added it now.

PR https://github.com/HistoryAtState/hsg-shell/pull/356 is relying on this fix, otherwise the new test will fail when opening page `departmenthistory/`.