### PR TITLE
fix(#372): Fix italics in links

### DIFF
--- a/modules/ext-html.xql
+++ b/modules/ext-html.xql
@@ -70,7 +70,11 @@ declare function pmf:ref($config as map(*), $node as element(), $class as xs:str
             "$app" || $target
         else
             $target
-    let $content := if ($content) then $content/string() else $href
+    let $content :=
+        if ($content) then
+            $config?apply-children($config, $node, $content)
+        else
+            $href
     (: let $content := if ($node/node()) then $config?apply-children($config, $node, .) else $href :)
     return
         <a href="{$href}">{$content}</a>


### PR DESCRIPTION
Render child nodes of links "<ref>" in pmf:ref instead of just
redenring the contained string, so that odd rules for child nodes like
"<hi>" can be applied.

Closes https://github.com/HistoryAtState/hsg-shell/issues/372