### PR TITLE
Ant build improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-You need to have *ant*, *git* and *nodeJS* (version 10.0.0 or higher) installed.
+You need to have *ant*, *git*, Chrome, and *nodeJS* (version 10.0.0 or higher) installed.
 
 ### hsg-project users
 
@@ -25,6 +25,16 @@ run:
 Then:
 
     source ~/.bash_profile
+
+If you don't have Google Chrome installed then you can either:
+
+1. Install it with homebrew:
+    ```
+    brew install --cask google-chrome
+    ```
+
+2. Download and install it from Google:
+    https://www.google.com/chrome
 
 ### Install global node packages
 

--- a/build.properties.xml
+++ b/build.properties.xml
@@ -8,8 +8,8 @@
         <title>history.state.gov 3.0 shell</title>
         <version>2.3.0</version>
     </app>
-    <npm>/usr/local/opt/node@10/bin/npm</npm>
-    <gulp>/usr/local/bin/gulp</gulp>
+    <npm>npm</npm>
+    <gulp>gulp</gulp>
     <node>
         <path>/usr/local/opt/node@10/bin:/usr/local/bin</path>
     </node>

--- a/build.xml
+++ b/build.xml
@@ -25,7 +25,7 @@
     
     <target name="clean">
         <echo message="Calling gulp clean..."/>
-        <exec executable="${gulp}" outputproperty="gulp.output">
+        <exec executable="${gulp}" outputproperty="gulp.output" failonerror="true">
             <arg line="clean"/>
             <env key="PATH" value="${node.path}:${env.PATH}"/>
         </exec>
@@ -38,7 +38,7 @@
     
     <target name="run-npm">
         <echo message="Calling npm start... (Production? ${node-env-is-set-for-production})"/>
-        <exec executable="${npm}" outputproperty="npm.output">
+        <exec executable="${npm}" outputproperty="npm.output" failonerror="true">
             <arg line="start"/>
             <env key="PATH" value="${node.path}:${env.PATH}"/>
             <env key="NODE_ENV" value="${NODE_ENV.production}"/>


### PR DESCRIPTION
1. Assumes that npm and gulp are all present on the PATH. This is the case for macOS packages installed via Homebrew, and also via nvm, and also for sensibly configured Linux systems. Therefore this now works "out-of-the-box" by default on more systems.
2. Stops the build if critical exec steps fail
3. Document the requirement that Google Chrome must be installed to build this