### PR TITLE
Fix display of footnote labels with non-numeric parts

### DIFF
--- a/app/scss/_miscellaneous.scss
+++ b/app/scss/_miscellaneous.scss
@@ -134,3 +134,23 @@ html input[disabled] {
     margin-right: 0;
   }
 }
+
+/* override default list styling since FRUS footnote labels may contain non-numeric values.
+ * by default, browsers only output leading numbers in li/@value, so in value="60a", the "a" was not shown. */
+.footnotes {
+  ol {
+    list-style: none;
+    padding-inline-start: 0px;
+    border-collapse: separate;
+    border-spacing: 0 $margin-vertical-base;
+  }
+  li {
+    display: table-row;
+  }   
+  li:before {
+    content: attr(value)".";
+    display: table-cell;
+    padding-right: 0.25rem;
+    text-align: right;
+  }
+}


### PR DESCRIPTION
Before, the footnotes for https://history.state.gov/historicaldocuments/frus1919Russia/d275 appeared as follows:

> <img width="624" alt="Screen Shot 2021-12-02 at 11 38 06 AM" src="https://user-images.githubusercontent.com/59118/144464313-1a9274f6-a28d-4f3f-ac85-29a0a530e646.png">

The source TEI for the middle footnote's label was `n="60a"`, and hsg-shell's frus.odd faithfully translated this value into the HTML `li/@value` attribute. So, why is the "a" truncated from "60a" when we view the document above? According to the [HTML specs for `li/@value`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/li#attributes):

> The only allowed value for this attribute is a number, even if the list is displayed with Roman numerals or letters. 

Browsers take the leading numbers and chop off trailing non-numeric content.

As a workaround, I adapted the approach from https://stackoverflow.com/questions/66527415/html-list-with-custom-decimal-numbers-using-value-of-li to overriding the default browser styling of `<ol>` and `<li>` elements. To force the footnote labels to be right-aligned, I adapted the approach from https://stackoverflow.com/questions/18990761/right-align-css-before-numbers.

With this change applied, here is how the example above looks:

> <img width="621" alt="Screen Shot 2021-12-02 at 11 44 56 AM" src="https://user-images.githubusercontent.com/59118/144465525-398615cd-19ad-4df5-8915-35ea66747456.png">

Closes https://github.com/HistoryAtState/hsg-shell/issues/389.