### PR TITLE
Ensure footnotes are suppressed from "inner" TOC views

### DIFF
--- a/modules/frus-toc-html.xqm
+++ b/modules/frus-toc-html.xqm
@@ -273,7 +273,7 @@ declare function toc:document-list($config as map(*), $node as element(tei:div),
                         <h4>Contents</h4>
                         <div style="padding-left: 1em">
                             <div class="toc-inner">
-                                <ul>{ toc:toc-inner($config, $node, false()) }</ul>
+                                <ul>{ toc:toc-inner($headConfig, $node, false()) }</ul>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
As reported in #391, inner TOC views were displaying footnotes. 

Before this PR, the TOC at https://history.state.gov/historicaldocuments/frus1941v06/comp1 shows footnotes on the child chapter divs:

> <img width="590" alt="Screen Shot 2021-12-02 at 12 27 43 PM" src="https://user-images.githubusercontent.com/59118/144472828-7a8a6e81-1846-433d-8a44-6367018a416e.png">

With this PR, the footnotes are suppressed:

> <img width="591" alt="Screen Shot 2021-12-02 at 12 27 54 PM" src="https://user-images.githubusercontent.com/59118/144472869-4d6ba226-b88f-4632-8f24-1bc850d01135.png">
 