### PR TITLE
Add HTTP Last-Modified header for TEI resources

### DIFF
--- a/modules/app.xqm
+++ b/modules/app.xqm
@@ -151,6 +151,10 @@ function app:handle-error($node as node(), $model as map(*), $code as xs:int?) {
             ()
 };
 
+declare function app:set-last-modified($last-modified as xs:dateTime) {
+    response:set-header("Last-Modified", format-dateTime($last-modified, "[FNn,*-3], [D01] [MNn,*-3] [Y0001] [H01]:[m01]:[s01] [Z0000]"))
+};
+
 declare function app:uri($node as node(), $model as map(*)) {
     <code>{request:get-attribute("hsg-shell.path")}</code>
 };

--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -115,6 +115,19 @@ declare variable $config:PUBLICATIONS :=
     map {
         "frus": map {
             "collection": $config:FRUS_VOLUMES_COL,
+            "document-last-modified": function($document-id) { 
+                (
+                    xmldb:last-modified($config:FRUS_VOLUMES_COL, $document-id || '.xml'),
+                    (: for volumes that we do not have as TEI yet, fall back on volume metadata :)
+                    xmldb:last-modified($config:FRUS_METADATA_COL, $document-id || '.xml')
+                )[1]
+            },
+            "section-last-modified": function($document-id, $section-id) {
+                (
+                    xmldb:last-modified($config:FRUS_VOLUMES_COL, $document-id || '.xml'),
+                    xmldb:last-modified($config:FRUS_METADATA_COL, $document-id || '.xml')
+                )[1]
+            },
             "select-document": function($document-id) { doc($config:FRUS_VOLUMES_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { 
                 let $node := doc($config:FRUS_VOLUMES_COL || '/' || $document-id || '.xml')/id($section-id) 
@@ -155,6 +168,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "buildings": map {
             "collection": $config:BUILDINGS_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:BUILDINGS_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:BUILDINGS_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:BUILDINGS_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:BUILDINGS_COL || '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/departmenthistory/" || string-join(($document-id, $section-id), '/') },
@@ -171,6 +186,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "conferences": map {
             "collection": $config:CONFERENCES_ARTICLES_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:CONFERENCES_ARTICLES_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:CONFERENCES_ARTICLES_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:CONFERENCES_ARTICLES_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:CONFERENCES_ARTICLES_COL || '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/conferences/" || string-join(($document-id, $section-id), '/') },
@@ -193,6 +210,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "countries": map {
             "collection": $config:COUNTRIES_ARTICLES_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:COUNTRIES_ARTICLES_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:COUNTRIES_ARTICLES_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:COUNTRIES_ARTICLES_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:COUNTRIES_ARTICLES_COL || '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/countries/" || string-join(($document-id, $section-id), '/') },
@@ -203,6 +222,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "countries-issues": map {
             "collection": $config:COUNTRIES_ISSUES_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:COUNTRIES_ISSUES_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:COUNTRIES_ISSUES_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:COUNTRIES_ISSUES_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:COUNTRIES_ISSUES_COL || '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/countries/issues/" || string-join(($document-id, $section-id), '/') },
@@ -213,6 +234,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "archives": map {
             "collection": $config:ARCHIVES_ARTICLES_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:ARCHIVES_ARTICLES_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:ARCHIVES_ARTICLES_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:ARCHIVES_ARTICLES_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:ARCHIVES_ARTICLES_COL || '/' || $document-id || '.xml')//tei:body },
             "html-href": function($document-id, $section-id) { "$app/countries/" || string-join(($document-id, $section-id), '/') },
@@ -222,6 +245,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "articles": map {
             "collection": $config:FRUS_HISTORY_ARTICLES_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:FRUS_HISTORY_ARTICLES_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:FRUS_HISTORY_ARTICLES_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:FRUS_HISTORY_ARTICLES_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:FRUS_HISTORY_ARTICLES_COL || '/' || $document-id || '.xml')//tei:body },
             "html-href": function($document-id, $section-id) { "$app/frus-history/" || string-join(($document-id, $section-id), '/') },
@@ -240,6 +265,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "people": map {
             "collection": $config:SECRETARY_BIOS_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:SECRETARY_BIOS_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:SECRETARY_BIOS_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:SECRETARY_BIOS_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:SECRETARY_BIOS_COL || '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/departmenthistory/people/" || string-join(($document-id, $section-id), '/') },
@@ -285,6 +312,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "milestones": map {
             "collection": $config:MILESTONES_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:MILESTONES_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:MILESTONES_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:MILESTONES_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:MILESTONES_COL|| '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/milestones/" || string-join(($document-id, $section-id), '/') },
@@ -295,6 +324,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "short-history": map {
             "collection": $config:SHORT_HISTORY_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:SHORT_HISTORY_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:SHORT_HISTORY_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:SHORT_HISTORY_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:SHORT_HISTORY_COL || '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/departmenthistory/" || string-join(($document-id, $section-id), '/') },
@@ -305,6 +336,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "timeline": map {
             "collection": $config:ADMINISTRATIVE_TIMELINE_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:ADMINISTRATIVE_TIMELINE_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:ADMINISTRATIVE_TIMELINE_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:ADMINISTRATIVE_TIMELINE_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:ADMINISTRATIVE_TIMELINE_COL || '/' || $document-id || '.xml')/id('chapter_' || $section-id) },
             "html-href": function($document-id, $section-id) { "$app/departmenthistory/" || string-join(($document-id, substring-after($section-id, 'chapter_')), '/') },
@@ -316,6 +349,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "faq": map {
             "collection": $config:FAQ_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:FAQ_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:FAQ_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:FAQ_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:FAQ_COL || '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/about/" || string-join(($document-id, $section-id), '/') },
@@ -325,6 +360,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "hac": map {
             "collection": $config:HAC_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:HAC_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:HAC_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:HAC_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:HAC_COL || '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/about/" || string-join(($document-id, $section-id), '/') },
@@ -334,6 +371,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "education": map {
             "collection": $config:EDUCATION_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:EDUCATION_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:EDUCATION_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:EDUCATION_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:EDUCATION_COL || '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/education/modules/" || string-join(($document-id, $section-id), '#') },
@@ -346,6 +385,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "frus-history-monograph": map {
             "collection": $config:FRUS_HISTORY_MONOGRAPH_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:FRUS_HISTORY_MONOGRAPH_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:FRUS_HISTORY_MONOGRAPH_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:FRUS_HISTORY_MONOGRAPH_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { 
                 let $target-section-id :=
@@ -392,6 +433,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "vietnam-guide": map {
             "collection": $config:VIETNAM_GUIDE_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:VIETNAM_GUIDE_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:VIETNAM_GUIDE_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:VIETNAM_GUIDE_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:VIETNAM_GUIDE_COL || '/' || $document-id || '.xml') },
             "html-href": function($document-id, $section-id) { "$app/historicaldocuments/" || string-join(($document-id, $section-id), '/') },
@@ -401,6 +444,8 @@ declare variable $config:PUBLICATIONS :=
         },
         "views-from-the-embassy": map {
             "collection": $config:VIEWS_FROM_EMBASSY_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:VIEWS_FROM_EMBASSY_COL, $document-id || '.xml') },  
+            "section-last-modified": function($document-id, $section-id) { xmldb:last-modified($config:VIEWS_FROM_EMBASSY_COL, $document-id || '.xml') },
             "select-document": function($document-id) { doc($config:VIEWS_FROM_EMBASSY_COL || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) { doc($config:VIEWS_FROM_EMBASSY_COL || '/' || $document-id || '.xml')/id($section-id) },
             "html-href": function($document-id, $section-id) { "$app/departmenthistory/wwi" },

--- a/modules/view.xql
+++ b/modules/view.xql
@@ -56,4 +56,12 @@ let $lookup := function($functionName as xs:string, $arity as xs:int) {
  :)
 let $content := request:get-data()
 return
-    templates:apply($content, $lookup, (), $config)
+    (
+        templates:apply($content, $lookup, (), $config),
+        let $last-modified := request:get-attribute("hsgshell.last-modified")
+        return
+            if (exists($last-modified)) then
+                app:set-last-modified($last-modified)
+            else
+                ()
+    )


### PR DESCRIPTION
As discussed with @windauer and agh, accurate dependable HTTP Last-Modified headers could aid in our efforts to improve efficiency and performance of our servers. This PR is an initial step toward that goal. 

It adds the Last-Modified header to resources on history.state.gov that are generated from TEI sources. Specifically, it defines new `*-last-modified` entries in `config.xqm`'s `$config:PUBLICATIONS` map, which the `pages:load` templating function retrieves when constructing the TEI data needed on a page. This function then sets a request attribute, `hsgshell.last-modified` (modeled on `hsg-shell.error`), containing the last-modified date. Then, after `view.xql` finishes executing `templates:apply`, it checks for the presence of this attribute and, if found, passes the value to `app:set-last-modified`, which formats the date according to RFC 1123 (see https://github.com/w3c/qtspecs/issues/36) and sends the formatted date to `response:set-header("Last-Modified")`.

Besides TEI resources, this PR adds a Last-Modified header for FRUS volumes that we don't have TEI for yet, by using the date of the resource in `/db/apps/frus/bibliography`.

The functions that look up last modified dates do so purely by looking up the last-modified date of TEI documents using the `xmldb:last-modified` function. It doesn't consider the last-modified date of the primary or any other imported HTML templates or XQuery modules, which could carry significant changes (i.e., site-wide menus, section sidebars, etc.). More nuanced handling could be added in a future PR.

Other than this one non-TEI case, the PR doesn't handle Last-Modified headers for any other non-TEI resource. These could be added in future PRs. 

However, since FRUS TEI contains some of the most taxing pages on the site, this PR should help us tell whether the addition of dependable Last-Modified headers is worthwhile.

In my local testing, the `Last-Modified` header is correctly set and updated as resources are stored in the database.