### PR TITLE
Implement COM "arrived" structure

### DIFF
--- a/modules/pocom-html.xqm
+++ b/modules/pocom-html.xqm
@@ -163,14 +163,14 @@ declare function pocom:principal-officers-by-role-id($node as node(), $model as 
                     let $person-id := $role/person-id
                     let $name := pocom:person-name-first-last($node, $model, $person-id)
                     let $start-date := 
-                        (: TODO: Confer with Evan Duncan about the following logic for determining term of service
-                           Prefer started-date, but use appointed-date for Principal Officers and Chiefs to Int'l Orgs if it's all we have
+                        (: TODO: Confer with Josh Botts about the following logic for determining term of service
+                           Prefer started-date/arrived-date, but use appointed-date for Principal Officers and Chiefs to Int'l Orgs if it's all we have
                         :)
                         if ($role-class = ('principal-position', 'org-mission')) then
-                            ($role/started/date, $role/appointed/date)[. ne ''][1]
+                            ($role/started/date, $role/arrived/date, $role/appointed/date)[. ne ''][1]
                         else
-                            (: For Chiefs of Mission, do not use the appointment date, only start date :)
-                            $role/started/date
+                            (: For Chiefs of Mission, do not use the appointment date :)
+                            ($role/started/date, $role/arrived/date)[. ne ''][1]
                     let $end-date :=
                         (: Career Ambassador is a permanent marker of distinguished service, so do not supply/suggest an end date :)
                         if ($role-title-id = 'career-ambassador') then 
@@ -354,6 +354,7 @@ declare function pocom:chiefs-by-country-id($node as node(), $model as map(*), $
                     let $startdate :=
                         (
                         $chief/started/date,
+                        $chief/arrived/date,
                         $chief/appointed/date
                         )[. ne ''][1]
                     let $start-date-english := if ($startdate) then app:date-to-english($startdate) else ()
@@ -578,14 +579,14 @@ declare function pocom:format-index($node as node(), $model as map(*), $people a
                             ", "
                         )
                     let $start-date := 
-                        (: TODO: Confer with Evan Duncan about the following logic for determining term of service
-                           Prefer started-date, but use appointed-date for Principal Officers and Chiefs to Int'l Orgs if it's all we have
+                        (: TODO: Confer with Josh Botts about the following logic for determining term of service
+                           Prefer started-date/arrived-date, but use appointed-date for Principal Officers and Chiefs to Int'l Orgs if it's all we have
                         :)
                         if ($role-class = ('principal-position', 'org-mission')) then
-                            ($role/appointed/date, $role/started/date)[. ne ''][1]
+                            ($role/appointed/date, $role/arrived/date, $role/started/date)[. ne ''][1]
                         else
-                            (: For Chiefs of Mission, do not use the appointment date, only start date :)
-                            $role/started/date
+                            (: For Chiefs of Mission, do not use the appointment date :)
+                            ($role/appointed/date, $role/arrived/date)[. ne ''][1]
                     let $end-date :=
                         (: Career Ambassador is a permanent marker of distinguished service, so do not supply/suggest an end date :)
                         if ($role-title-id = 'career-ambassador') then 
@@ -683,11 +684,13 @@ declare function pocom:format-role($person, $role) {
         else 
             ()
     let $appointed := $role/appointed
+    let $arrived := $role/arrived
     let $started := $role/started
     let $ended := $role/ended
     let $startdate :=
         (
         $started/date,
+        $arrived/date,
         $appointed/date
         )[. ne ''][1]
     let $dates :=
@@ -700,11 +703,13 @@ declare function pocom:format-role($person, $role) {
             else if ($role-title-id = ('charge-daffaires-ad-interim')) then
                 (
                 if ($started/date ne '') then (normalize-space(concat('Began Service: ', $started/note, ' ', app:date-to-english($started/date))), <br/>) else (),
+                if ($arrived/date ne '') then (normalize-space(concat('Assumed Charge: ', $arrived/note, ' ', app:date-to-english($arrived/date))), <br/>) else (),
                 if ($ended/date ne '') then normalize-space(concat('Ended Service: ', $ended/note, ' ', app:date-to-english($ended/date) )) else ()
                 )
             else (: if ($roleclass = ('country-mission', 'org-mission')) then :)
                 (
                 if ($appointed/date ne '') then (normalize-space(concat('Appointed: ', $appointed/note, ' ', app:date-to-english($appointed/date))), <br/>) else (),
+                if ($arrived/date ne '') then (normalize-space(concat('Assumed Charge: ', $arrived/note, ' ', app:date-to-english($arrived/date))), <br/>) else (),
                 if ($started/date ne '') then (normalize-space(concat('Presentation of Credentials: ', $started/note, ' ', app:date-to-english($started/date))), <br/>) else (),
                 if ($ended/date ne '') then normalize-space(concat('Termination of Mission: ', $ended/note, ' ', app:date-to-english($ended/date) )) else ()
                 )

--- a/pages/departmenthistory/people/principals-chiefs.xml
+++ b/pages/departmenthistory/people/principals-chiefs.xml
@@ -225,7 +225,8 @@
                             principal diplomatic representative of the United States Government.
                             Both assumption of charge over the U.S. mission and presentation of
                             credentials to the host government are important elements of a chief of
-                            mission’s entrance on duty. An effort has been made to fix a date for
+                            mission’s entrance on duty. As of 2019, “Assumed Charge” dates are
+                            tracked for Chiefs of Mission. An effort has been made to fix a date for
                             the termination of the diplomatic mission of each representative
                             vis-à-vis the host government and to describe briefly in each individual
                             case (and as precisely as sometimes incomplete records permit) what

--- a/pages/departmenthistory/people/principals-chiefs.xml
+++ b/pages/departmenthistory/people/principals-chiefs.xml
@@ -218,25 +218,30 @@
                         <dd>These dates are included on a position-by-position basis. Principal
                             officers of the Department of State who are Presidential appointees have
                             a date of appointment, date of entry on duty, and date of termination of
-                            appointment. Chiefs of Mission are considered to have entered on duty
-                            when they present their credentials to their host governments. An effort
-                            has been made to fix a date for the termination of the diplomatic
-                            mission of each representative vis-à-vis the host government and to
-                            describe briefly in each individual case (and as precisely as sometimes
-                            incomplete records permit) what action or event brought the mission to
-                            either a formal or a de facto close. In the nineteenth century it was
-                            customary for a Chief of Mission to present his own letter of recall; in
-                            current practice most missions terminate in actual fact with the
-                            departure of the Ambassador from his or her post. In all periods there
-                            have been special circumstances (e.g., death, declaration of war,
-                            severance of diplomatic relations) which have brought some diplomatic
-                            missions to an end. It should be emphasized that the effective date of a
-                            Chief of Mission's resignation frequently does not coincide with the
-                            date shown here for the termination of his or her mission abroad. For
-                            those who were designated by the Secretary of State, the date of
-                            appointment is the same as the date of entry on duty. For Chargés
-                            d’Affaires ad interim, dates of service are listed from and to the
-                            nearest month.</dd>
+                            appointment. Upon assuming charge of their mission, Chiefs of Mission
+                            possess the authority and responsibility to manage their post and
+                            oversee the conduct of its operations. Upon presenting their credentials
+                            to the host government, Chiefs of Mission are recognized as the
+                            principal diplomatic representative of the United States Government.
+                            Both assumption of charge over the U.S. mission and presentation of
+                            credentials to the host government are important elements of a chief of
+                            mission’s entrance on duty. An effort has been made to fix a date for
+                            the termination of the diplomatic mission of each representative
+                            vis-à-vis the host government and to describe briefly in each individual
+                            case (and as precisely as sometimes incomplete records permit) what
+                            action or event brought the mission to either a formal or a de facto
+                            close. In the nineteenth century it was customary for a Chief of Mission
+                            to present his own letter of recall; in current practice most missions
+                            terminate in actual fact with the departure of the Ambassador from his
+                            or her post. In all periods there have been special circumstances (e.g.,
+                            death, declaration of war, severance of diplomatic relations) which have
+                            brought some diplomatic missions to an end. It should be emphasized that
+                            the effective date of a Chief of Mission's resignation frequently does
+                            not coincide with the date shown here for the termination of his or her
+                            mission abroad. For those who were designated by the Secretary of State,
+                            the date of appointment is the same as the date of entry on duty. For
+                            Chargés d’Affaires ad interim, dates of service are listed from and to
+                            the nearest month.</dd>
                     </dl>
                     <h3 id="key-terms">Key Terms</h3>
                     <dl>
@@ -265,7 +270,7 @@
                             person whom he wishes to appoint to a high-level position. Article II,
                             Section 2 of the Constitution states that the President, “by and with
                             the Advice and Consent of the Senate, shall appoint Ambassadors, other
-                            public Ministers and Consuls, Judges of the supreme Court, and all other
+                            public Ministers and Consuls, Judges of the Supreme Court, and all other
                             Officers of the United States, whose Appointments are not herein
                             otherwise provided for, and which shall be established by Law.” Per <a
                                 href="https://www.rules.senate.gov/rules-of-the-senate">Senate Rule

--- a/pages/departmenthistory/people/principals-chiefs.xml
+++ b/pages/departmenthistory/people/principals-chiefs.xml
@@ -145,7 +145,7 @@
                         charge of a diplomatic mission of the United States or of a United States
                         office abroad which is designated by the Secretary of State as diplomatic in
                         nature, including any individual assigned under section 502(c) to be
-                        temporarily in charge of such a mission or office."</p>
+                        temporarily in charge of such a mission or office.”</p>
                     <p>The Chief of Mission is often—but not always—an Ambassador. There are
                         currently three classes of diplomatic representation established by the <a
                             href="https://2009-2017.state.gov/documents/organization/17843.pdf">1961
@@ -224,8 +224,8 @@
                             to the host government, Chiefs of Mission are recognized as the
                             principal diplomatic representative of the United States Government.
                             Both assumption of charge over the U.S. mission and presentation of
-                            credentials to the host government are important elements of a chief of
-                            mission’s entrance on duty. As of 2019, “Assumed Charge” dates are
+                            credentials to the host government are important elements of a Chief of
+                            Mission’s entrance on duty. As of 2019, “Assumed Charge” dates are
                             tracked for Chiefs of Mission. An effort has been made to fix a date for
                             the termination of the diplomatic mission of each representative
                             vis-à-vis the host government and to describe briefly in each individual
@@ -237,7 +237,7 @@
                             or her post. In all periods there have been special circumstances (e.g.,
                             death, declaration of war, severance of diplomatic relations) which have
                             brought some diplomatic missions to an end. It should be emphasized that
-                            the effective date of a Chief of Mission's resignation frequently does
+                            the effective date of a Chief of Mission’s resignation frequently does
                             not coincide with the date shown here for the termination of his or her
                             mission abroad. For those who were designated by the Secretary of State,
                             the date of appointment is the same as the date of entry on duty. For


### PR DESCRIPTION
See https://github.com/HistoryAtState/pocom/issues/29

@joshbotts If you send me the text to be added to ["Dates of Service"](https://history.state.gov/departmenthistory/people/principals-chiefs#dates-of-service) on the POCOM landing page, I can fold it into the [the HTML template](https://github.com/HistoryAtState/hsg-shell/blob/master/pages/departmenthistory/people/principals-chiefs.xml) and include it in this PR.

## Individual country chief

e.g., http://localhost:8080/exist/apps/hsg-shell/departmenthistory/people/popp-william-w

**Before**

> <img width="510" alt="Screen Shot 2022-02-05 at 11 39 40 AM" src="https://user-images.githubusercontent.com/59118/152652218-2a94a658-827e-4e49-a1fa-531742f39b46.png">

**After**

> <img width="512" alt="Screen Shot 2022-02-05 at 11 40 03 AM" src="https://user-images.githubusercontent.com/59118/152652227-8caf8d83-9f67-4773-b747-591db4dd681b.png">

## Chiefs to country

e.g., http://localhost:8080/exist/apps/hsg-shell/departmenthistory/people/chiefsofmission/brazil

**Before**

> <img width="280" alt="Screen Shot 2022-02-05 at 12 11 00 PM" src="https://user-images.githubusercontent.com/59118/152652261-9a562146-09db-46bc-99e7-51fbfd197d89.png">

**After**

> <img width="409" alt="Screen Shot 2022-02-05 at 12 11 12 PM" src="https://user-images.githubusercontent.com/59118/152652271-24375bb2-caa1-4ad3-95a4-731bf9b21178.png">

## Chiefs to IO

e.g., http://localhost:8080/exist/apps/hsg-shell/departmenthistory/people/lapenn-jessica

**Before**

> <img width="420" alt="Screen Shot 2022-02-05 at 12 21 05 PM" src="https://user-images.githubusercontent.com/59118/152652290-411ffae3-1124-4379-8934-5f5062999da4.png">

**After**

> <img width="418" alt="Screen Shot 2022-02-05 at 12 21 12 PM" src="https://user-images.githubusercontent.com/59118/152652293-ec642cb3-9998-49e5-bb3d-a7210deb6c03.png">