### PR TITLE
Ensure results of 'validate-replication' are never cached

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -106,7 +106,9 @@ else if (ends-with($exist:path, "resource-name.xml")) then
 (: handle requests for validate-replication:)
 else if (ends-with($exist:path, "validate-replication")) then
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-        <forward url="{$exist:controller}/tests/xquery/validate-replication.xq"/>
+        <forward url="{$exist:controller}/tests/xquery/validate-replication.xq">
+            <set-header name="Cache-Control" value="no-store"/>
+        </forward>
     </dispatch>
    
    


### PR DESCRIPTION
Replication tests use this URI to trigger a replication event.
If the response to this URI is cached anywhere, the replication event might not get triggered.
This leads to wrongly failing replication tests.
This PR ensure results of 'validate-replication' are never cached.