### PR TITLE
fix: fix bootstrap-sass version for ant build

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "jquery": "^2.2.0",
-    "bootstrap-sass": "^3.3.6",
+    "bootstrap-sass": "3.3.6",
     "font-awesome": "^4.5.0",
     "animate.css": "^3.5.1"
   }


### PR DESCRIPTION
currently the ant build command is failing due to bootstrap-sass 
the script is trying to fetch a newer version which has some breaking changes
@joewiz these changes will fix the build process