### PR TITLE
Fix broken ant task `xmlvalidate` caused by empty html attribute in main page template

### DIFF
--- a/app/templates/site.xml
+++ b/app/templates/site.xml
@@ -330,7 +330,7 @@
         <script type="text/javascript" async="async" src="$app/resources/scripts/app.all.js"
             data-template="app:fix-this-link"/>
         <!-- Google tag (gtag.js) -->
-        <script async src="https://www.googletagmanager.com/gtag/js?id=G-GWKX1LXFD1"></script>
+        <script async="async" src="https://www.googletagmanager.com/gtag/js?id=G-GWKX1LXFD1"></script>
         <script>
         window.dataLayer = window.dataLayer ||[];
         function gtag() {


### PR DESCRIPTION
This open source contribution to the HSG-Shell project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.