### PR TITLE
downgrade node-chromedriver version to 91

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "bower": "^1.8.8",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
-    "chromedriver": "^110.0.0",
+    "chromedriver": "^91.0.0",
     "del": "^5.1.0",
     "gulp": "^4.0.2",
     "gulp-autoprefixer": "^7.0.1",


### PR DESCRIPTION
Currently the CI machine is still using `node 10.24.1` 
The updated `chromedriver` version does not work on `node 10.24.1` we need to downgrade to version `91.0.0` .
For the tests to run again on the CI machine we need the old version
this downgrade won't have an effect on users using `node 17` & the tests will run just fine