### PR TITLE
fix(app.js): Switch OSD settings from local IIIF server to production

### DIFF
--- a/resources/scripts/app.js
+++ b/resources/scripts/app.js
@@ -7,19 +7,17 @@ function initializeImageViewer() {
             tif_url    = osd_viewer.attr('data-url'),
             tif_width  = parseInt(osd_viewer.attr('data-width')),
             tif_height = parseInt(osd_viewer.attr('data-height')),
-            scheme     = 'http',
-            server     = 'localhost', // Local Cantaloupe image server for development
-            port       = '8182',
+            scheme     = 'https',
+            server     = 'ci.history.state.gov',
             debugMode  = false;
 
-        console.log('Image URI=', scheme + '://' + server + ':' + port + '/iiif/3/' + documentId + '%2Ftiff%2F' + facsId + '.tif');
+        console.log('Image URI=', scheme + "://" + server +  "/iiif/2/" + documentId + "%2Ftiff%2F" + facsId + ".tif");
 
         var viewer = OpenSeadragon({
             id:                   "viewer",
             prefixUrl:            "resources/images/OSD-icons/",
             preserveViewport:     true,
             visibilityRatio:      1,
-            //minZoomLevel:         1,
             minZoomImageRatio:    0.9,
             defaultZoomLevel:     1,
             showNavigator:        true,
@@ -28,8 +26,8 @@ function initializeImageViewer() {
             showSequenceControl:  false,
             debugMode:            debugMode,
             tileSources:   [{
-              "@context": "http://iiif.io/api/image/3/context.json",
-              "@id":      scheme + "://" + server + ':' + port + "/iiif/3/" + documentId + "%2Ftiff%2F" + facsId + ".tif",
+              "@context": "http://iiif.io/api/image/2/context.json",
+              "@id":      scheme + "://" + server +  "/iiif/2/frus%2F" + documentId + "%2Ftiff%2F" + facsId + ".tif",
               "height":   tif_height,
               "width":    tif_width,
               "maxArea":  10000000,


### PR DESCRIPTION
The current IIIF Cantaloupe server has version 4.1.11, but the development settings have been made for Cantaloupe 5, which supports the lastest IIIF Image API 3. Cantaloupe 4x only supports up to IIIF Image API 2, therefore switched back to 2 (https://cantaloupe-project.github.io/manual/4.1/endpoints.html).

---

This open source contribution to the `hsg-shell` project was commissioned by the Office of the Historian, U.S. Department of State, https://history.state.gov/.