### PR TITLE
Fix last-modified error on frus-history (sesqui) document pages

### DIFF
--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -680,6 +680,9 @@ declare variable $config:PUBLICATIONS :=
               }
         },
         "frus-history-documents": map {
+            "collection": $config:FRUS_HISTORY_DOCUMENTS_COL,
+            "document-last-modified": function($document-id) { xmldb:last-modified($config:FRUS_HISTORY_DOCUMENTS_COL, $document-id || '.xml') },  
+            "document-created": function($document-id) { xmldb:created($config:FRUS_HISTORY_DOCUMENTS_COL, $document-id || '.xml') },
             "next": frus-history:get-next-doc#1,
             "previous": frus-history:get-previous-doc#1,
             "select-document": function($document-id) { doc($config:FRUS_HISTORY_DOCUMENTS_COL || "/" || $document-id || ".xml") },


### PR DESCRIPTION
The error could be seen on pages like https://history.state.gov/historicaldocuments/frus-history/documents/1959-11-06-hac-meeting-minutes (and others linked from the `documents` parent slug) and indicated that the expected `document-last-modified` function in `$config:PUBLICATIONS` was missing. This PR adds this function to the `frus-history-documents` entry. (A `document-last-modified` or `section-last-modified` function is only expected (a) when `pages:load` is called and (b) when there's both a `$publication-id` and `$document-id` parameter.)

```text
err:XPTY0004 Expected exactly one item for the function to be called, got 0. Expression: map:get($config:PUBLICATIONS, untyped-value-check[xs:anyAtomicType, $publication-id])?document-last-modified [at line 145, column 55, source: /db/apps/hsg-shell/modules/pages.xqm]
In function:
	pages:last-modified(xs:string, xs:string, xs:string?) [61:63:/db/apps/hsg-shell/modules/pages.xqm]
	pages:load(node(), map(*), xs:string?, xs:string?, xs:string?, xs:string, xs:boolean, xs:string?, xs:string?, xs:string?) [-1:-1:/db/apps/hsg-shell/modules/pages.xqm]
	templates:process-output(element(), map(*), item()*, element(function)) [211:9:/usr/local/existdb/exist620/etc/../data/expathrepo/templating-1.1.0/content/templates.xqm]
	templates:call-by-introspection(element(), map(*), map(*), function(*)) [189:28:/usr/local/existdb/exist620/etc/../data/expathrepo/templating-1.1.0/content/templates.xqm]
	templates:call(item(), element(), map(*)) [137:36:/usr/local/existdb/exist620/etc/../data/expathrepo/templating-1.1.0/content/templates.xqm]
	templates:process(node()*, map(*)) [133:51:/usr/local/existdb/exist620/etc/../data/expathrepo/templating-1.1.0/content/templates.xqm]
	templates:process(node()*, map(*)) [90:9:/usr/local/existdb/exist620/etc/../data/expathrepo/templating-1.1.0/content/templates.xqm]
	templates:apply(node()+, function(*), map(*)?, map(*)?) [66:9:/usr/local/existdb/exist620/etc/../data/expathrepo/templating-1.1.0/content/templates.xqm]
```

@line-o This PR fixes the error in my testing, but since you're working on related changes, please let me know if we shouldn't merge and apply this change. Thanks!