### PR TITLE
Advise crawlers not to follow pb links

### DIFF
--- a/modules/ext-html.xql
+++ b/modules/ext-html.xql
@@ -117,7 +117,7 @@ declare function pmf:pb-link($config as map(*), $node as node(), $class as xs:st
                 'Typeset '
             default return ''
     return
-        <a href="{ $uri }" id="{ $id }" class="{ $class }" target="_self">
+        <a href="{ $uri }" id="{ $id }" class="{ $class }" target="_self" rel="nofollow">
             [{$label, $config?apply-children($config, $node, $content)}]
         </a>
 };


### PR DESCRIPTION
We see a lot of crawlers hitting FRUS page image pages. Since these pages have no text content, search engines needn't index these pages. This doesn't prevent anyone from visiting these pages; it just advises bots that they shouldn't follow links to these pages. Hopefully it'll prevent some unnecessary traffic to a very large collection of pages (~ half a million).