### PR TITLE
Redirect requests with multiple slashes

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -94,6 +94,12 @@ else if (ends-with($exist:path, "/")) then
         <redirect url="{replace(local:uri(), '/$', '')}"/>
     </dispatch>
 
+(: strip multiple slashes :)
+else if (contains($exist:path, "//")) then
+    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
+        <redirect url="{replace(local:uri(), '/+', '/')}"/>
+    </dispatch>
+
 (: handle requests for static resources: css, js, images, etc. :)
 else if (contains($exist:path, "/resources/")) then
     <dispatch xmlns="http://exist.sourceforge.net/NS/exist">

--- a/repo.xml
+++ b/repo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<meta xmlns="http://exist-db.org/xquery/repo" commit-id="b1e5c1de1bc4eddad35399a95d373c50bf5f1a42" commit-time="1741021769">
+<meta xmlns="http://exist-db.org/xquery/repo" commit-id="de0a400fbe4ad8ac17dd454843ef963df72fee25" commit-time="1742302841">
     <description>history.state.gov 3.0 shell</description>
     <author/>
     <website/>


### PR DESCRIPTION
Instead of ignoring multiple slashes, redirect requests containing multiple adjacent slashes to the URL with only one.

Now, this URL:

  https://history.state.gov///////////////historicaldocuments/frus1901/d1

... will be redirected to:

  https://history.state.gov/historicaldocuments/frus1901/d1

(They were ignored because we determined the slugs in a path (`$path-parts`) using the expression `tokenize($exist:path, "/")[. ne ""]`. That's fine, but the side effect was serving up resources at unexpected/non-canonical paths.)