### PR TITLE
Remove fax number from OH contact info

### DIFF
--- a/app/templates/site.xml
+++ b/app/templates/site.xml
@@ -327,7 +327,6 @@
                                 <a href="mailto:history@state.gov">history@state.gov</a>
                             </p>
                             <p>Phone: 202-955-0200</p>
-                            <p>Fax: 202-955-0268</p>
                         </address>
                     </div>
                 </div>

--- a/pages/about/contact-us.xml
+++ b/pages/about/contact-us.xml
@@ -42,8 +42,8 @@
                             </ul>
                         </p>
                         <p>The Office of the Historian can be reached via email at <a
-                                href="mailto:history@state.gov">history@state.gov</a>, by phone at
-                            202-955-0259, or by fax at 202-955-0268.</p>
+                                href="mailto:history@state.gov">history@state.gov</a> or by phone at
+                            202-955-0259.</p>
                     </div>
                 </div>
                 <aside data-template="pages:asides"/>

--- a/repo.xml
+++ b/repo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<meta xmlns="http://exist-db.org/xquery/repo" commit-id="1da8b3e9c9aeb8989a16c7039b82020c160de8db" commit-time="1747329769">
+<meta xmlns="http://exist-db.org/xquery/repo" commit-id="dfbe5c8db703da778d2bb5db27f69a6dcb02b286" commit-time="1747411070">
     <description>history.state.gov 3.0 shell</description>
     <author/>
     <website/>


### PR DESCRIPTION
Via Alina, “We don't have a fax machine anymore so the number can be deleted.”