### PR TITLE
Add handling for gap with whitespace

### DIFF
--- a/modules/ext-html.xql
+++ b/modules/ext-html.xql
@@ -121,3 +121,10 @@ declare function pmf:pb-link($config as map(*), $node as node(), $class as xs:st
             [{$label, $config?apply-children($config, $node, $content)}]
         </a>
 };
+
+declare function pmf:gap($config as map(*), $node as node(), $class as xs:string+, $content, $unit as xs:string, $quantity as xs:integer) as xs:string {
+    switch ($unit)
+        case "char" return
+            string-join(((1 to $quantity) ! "&#160;"))
+        default return ""
+};

--- a/resources/odd/source/frus.odd
+++ b/resources/odd/source/frus.odd
@@ -312,6 +312,10 @@
                     <model behaviour="inline"/>
                 </elementSpec>
                 <elementSpec ident="gap" mode="change">
+                    <model predicate="exists(@unit) and @quantity castable as xs:integer" behaviour="gap">
+                        <param name="unit">@unit</param>
+                        <param name="quantity">@quantity cast as xs:integer</param>
+                    </model>
                     <model behaviour="omit"/>
                 </elementSpec>
                 <!-- Elements not in TEI Simple -->


### PR DESCRIPTION
Generate non-breaking spaces for omissions in the original, e.g., `<gap unit="chars" quantity="15"/>`

DO NOT MERGE until we find out why hsg-shell's rebuild.xql (i.e., `http://localhost:8080/exist/apps/hsg-shell/modules/rebuild.xql`) is producing this unexpected error:

```xml
<exception>
    <path>/db/apps/hsg-shell/modules/rebuild.xql</path>
    <message>exerr:ERROR Could not locate collection: /transform [at line 152, column 36, source: /exist/etc/../data/expathrepo/tei-publisher-lib-2.10.1/content/util.xql]
        In function:
        pmu:process-odd(document-node(), xs:string, xs:string, xs:string, element(modules)?, xs:boolean?) [120:9:/exist/etc/../data/expathrepo/tei-publisher-lib-2.10.1/content/util.xql]
        pmu:process-odd(document-node(), xs:string, xs:string, xs:string, element(modules)?) [20:30:/exist/etc/../data/expathrepo/tei-publisher-lib-2.10.1/content/util.xql]</message>
</exception>
```

This error occurs even without this PR, and it prevents regeneration of `/db/apps/hsg-shell/resources/odd/compiled/frus-web.xql`, which means that the typeswitch for gap remains as follows:

```xquery
case element(gap) return
    html:omit($config, ., ("tei-gap"), .)
```

... instead of this:

```xquery
case element(gap) return
    if (exists(@unit) and @quantity castable as xs:integer) then
        ext-html:gap($config, ., ("tei-gap"), ., @unit, @quantity cast as xs:integer)
    else
        html:omit($config, ., ("tei-gap"), .)
```

Applying this change manually confirms that the ODD and custom extension function works as expected:

> ![Screenshot 2025-07-01 at 16 41 07](https://github.com/user-attachments/assets/3450e0d9-8827-4b90-84c3-645d97175ce9)
