### PR TITLE
Handle case when first chapter is anticipated

### DIFF
--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -178,9 +178,15 @@ declare variable $config:PUBLICATIONS :=
             "select-document": function($document-id) { doc($config:FRUS_COL_VOLUMES || '/' || $document-id || '.xml') },
             "select-section": function($document-id, $section-id) {
                 let $node := doc($config:FRUS_COL_VOLUMES || '/' || $document-id || '.xml')/id($section-id) 
+                let $some-published := root($node)//tei:publicationDesc[@status eq ("published", "partially-published")]
                 return
+                    (: return 404s for interior divs from volumes that are not yet at least partially published, 
+                       since we may need to publish TEI containing just chapter titles, 
+                       when publication of a chapter is anticipated :)
+                    if (not($some-published)) then
+                        ()
                     (: most requests will be for divs :)
-                    if ($node instance of element(tei:div)) then
+                    else if ($node instance of element(tei:div)) then
                         $node
                     (: catch requests for TEI/@xml:id :)
                     else if ($node instance of element(tei:TEI)) then

--- a/modules/frus-html.xqm
+++ b/modules/frus-html.xqm
@@ -553,6 +553,7 @@ declare function fh:list-anticipated-volumes($volumes) {
             else
                 $vol-title-complete
         let $chapters := $vol//tei:change[starts-with(@corresp, "#ch")]
+        let $some-published := $vol//tei:revisionDesc[@status = ("published", "partially-published")]
         let $chapters-anticipated := $chapters[@status eq "being-cleared" and @to ne ""]
         order by $vol-id
         return
@@ -561,13 +562,22 @@ declare function fh:list-anticipated-volumes($volumes) {
             else
                 <li><a href="$app/historicaldocuments/{$vol-id}">{$vol-title-to-show}</a>
                     {
-                        <ul style="list-style-type: disc">{
-                            for $chapter in $chapters-anticipated
-                            let $div-id := substring-after($chapter/@corresp, "#")
-                            let $title := $vol/id($div-id)/tei:head
-                            return
-                                <li style="margin-bottom: 0px"><a href="$app/historicaldocuments/{$vol-id}/{$div-id}">{$title/string()}</a></li>
-                        }</ul>
+                        if ($some-published) then
+                            <ul style="list-style-type: disc">{
+                                for $chapter in $chapters-anticipated
+                                let $div-id := substring-after($chapter/@corresp, "#")
+                                let $title := $vol/id($div-id)/tei:head
+                                return
+                                    <li style="margin-bottom: 0px"><a href="$app/historicaldocuments/{$vol-id}/{$div-id}">{$title/string()}</a></li>
+                            }</ul>
+                        else
+                            <ul style="list-style-type: disc">{
+                                for $chapter in $chapters-anticipated
+                                let $div-id := substring-after($chapter/@corresp, "#")
+                                let $title := $vol/id($div-id)/tei:head
+                                return
+                                    <li style="margin-bottom: 0px">{$title/string()}</li>
+                            }</ul>
                     }
                 </li>       
     }</ol>
@@ -583,6 +593,7 @@ declare function fh:list-in-production-volumes($volumes) {
                 substring-after($vol-title-complete, 'Foreign Relations of the United States, ')
             else
                 $vol-title-complete
+        let $some-published := $vol//tei:revisionDesc[@status = ("published", "partially-published")]
         let $chapters := $vol//tei:change[starts-with(@corresp, "#ch")]
         let $chapters-anticipated := $chapters[@status eq "being-cleared"]
         order by $vol-id
@@ -593,11 +604,18 @@ declare function fh:list-in-production-volumes($volumes) {
                 <li><a href="$app/historicaldocuments/{$vol-id}">{$vol-title-to-show}</a>
                     {
                         <ul style="list-style-type: disc">{
-                            for $chapter in $chapters-anticipated
-                            let $div-id := substring-after($chapter/@corresp, "#")
-                            let $title := $vol/id($div-id)/tei:head
-                            return
-                                <li style="margin-bottom: 0px"><a href="$app/historicaldocuments/{$vol-id}/{$div-id}">{$title/string()}</a></li>
+                            if ($some-published) then
+                                for $chapter in $chapters-anticipated
+                                let $div-id := substring-after($chapter/@corresp, "#")
+                                let $title := $vol/id($div-id)/tei:head
+                                return
+                                    <li style="margin-bottom: 0px"><a href="$app/historicaldocuments/{$vol-id}/{$div-id}">{$title/string()}</a></li>
+                            else
+                                for $chapter in $chapters-anticipated
+                                let $div-id := substring-after($chapter/@corresp, "#")
+                                let $title := $vol/id($div-id)/tei:head
+                                return
+                                    <li style="margin-bottom: 0px">{$title/string()}</li>
                         }</ul>
                     }
                 </li>       

--- a/modules/frus-toc-html.xqm
+++ b/modules/frus-toc-html.xqm
@@ -54,17 +54,23 @@ declare function toc:prepare-sidebar-toc-list($nodes as node()*) {
 
 declare function toc:toc($model as map(*), $root as node()?, $show-heading as xs:boolean?, $highlight as xs:boolean?) {
     if ($root) then
-        <div class="toc-inner">
-            { if ($show-heading) then <div><h2>{toc:volume-title($root, "volume")}</h2></div> else () }
-            <ul>
-            {
-                toc:toc-passthru(
-                    $model,
-                    $root/ancestor-or-self::tei:TEI/tei:text,
-                    if ($highlight) then $root/ancestor-or-self::tei:div[@type != ("document", "document-pending")][1] else ()
-                )
-            }</ul>
-        </div>
+        let $some-published := root($root)//tei:revisionDesc[@status = ("published", "partially-published")]
+        return
+            (: only show a TOC if the volume is published or partially published :)
+            if ($some-published) then
+                <div class="toc-inner">
+                    { if ($show-heading) then <div><h2>{toc:volume-title($root, "volume")}</h2></div> else () }
+                    <ul>
+                    {
+                        toc:toc-passthru(
+                            $model,
+                            $root/ancestor-or-self::tei:TEI/tei:text,
+                            if ($highlight) then $root/ancestor-or-self::tei:div[@type != ("document", "document-pending")][1] else ()
+                        )
+                    }</ul>
+                </div>
+            else
+                ()
     else
         ()
 };


### PR DESCRIPTION
We may need to publish TEI containing just chapter titles, when the publication of the first of a volume's chapters is anticipated. In this case, the status of the series page shouldn’t link to any chapters shown, and the volume landing page shouldn’t display a table of contents.