### PR TITLE
test: align short-history p2 heading level with production build

### DIFF
--- a/tests/specs/departmenthistory/prod_shorthistory_titles.spec.js
+++ b/tests/specs/departmenthistory/prod_shorthistory_titles.spec.js
@@ -15,7 +15,7 @@ const subpages = [
   {
     name: 'p2',
     link: 'departmenthistory/short-history/foundations',
-    level:'h3',
+    level:'h2',
     title: 'Foundations of Foreign Affairs, 1775-1823'
   },
   {


### PR DESCRIPTION
## Summary
- Update `prod_shorthistory_titles.spec.js` p2 (foundations) `level` from `h3` to `h2`.
- Fixes the Jenkins prod-preview3 failure: `element ("#content-inner h3") still not existing after 10000ms`.

## Why
The wdio `jenkins` suite targets a server built with `HSG_ENV=production`, which flattens TEI heading rendering for the foundations subpage:

| build | rendered headline |
| --- | --- |
| dev (no `HSG_ENV`) | `<h3>Foundations of Foreign Affairs, …</h3>` |
| production | `<h2 class="tei-head7">Foundations of Foreign Affairs, 1775-1823</h2>` |

The spec was pinned to `h3`, which matched local dev runs but not the Jenkins target. p1 (h1) and p3 (h2) render identically in both builds, so only p2's pin needs to change.

## Test plan
- [x] Local dev build (no `HSG_ENV`) — *won't pass after this change*, but local engineers can rebuild with `HSG_ENV=production` to mirror the Jenkins/preview environment.
- [x] Local production build (`HSG_ENV=production` then redeployed) — `wdio … --spec tests/specs/departmenthistory/prod_shorthistory_titles.spec.js` → 3 passing in 2.1s.
- [ ] Jenkins `hsg-prod-preview3` rerun once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)