### PR TITLE
ci: unblock release job when latest exist-db image fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,12 @@ jobs:
           NODE_PATH: ${{ github.workspace }}/node_modules
   build:
     runs-on: ubuntu-latest
+    # The latest exist-db image (7.0.0-SNAPSHOT on Java 21) is currently
+    # unstable and fails at "wait for install to finish" -- an upstream
+    # eXist issue, not an hsg-shell regression. Mark that cell
+    # continue-on-error so it doesn't block the release job, which has
+    # `needs: [commitlint, build]` and was being skipped on every push.
+    continue-on-error: ${{ matrix.exist-version == 'latest' }}
     strategy:
        fail-fast: false
        matrix:


### PR DESCRIPTION
## Summary
- Mark the `(exist-version: latest, java-version: 21)` matrix cell of the `build` job as `continue-on-error`.
- Unblocks the `Release` job, which has `needs: [commitlint, build]` and was being skipped because that one cell consistently fails.

## Why
Since April 7 no new release has been cut despite several merged `fix:` PRs — including the marine-corps page (#597). Tracing it:

- `Release` depends on the whole `build` matrix succeeding.
- The `build` matrix has two effective cells after excludes: `(release, 11)` and `(latest, 21)`.
- `(latest, 21)` fails at "wait for install to finish" — an upstream eXist 7.0.0-SNAPSHOT issue, not an hsg-shell regression.
- One failed cell ⇒ `build` reports failure ⇒ `release` is skipped.

`continue-on-error` lets that cell still run and fail visibly (so the team notices when upstream is fixed) without blocking downstream jobs.

## Test plan
- [ ] Merge → push to `master` → confirm `Release` job runs and `npx semantic-release` cuts a patch release picking up the queued `fix:` commits (marine-corps page, etc.).
- [ ] Confirm `(latest, 21)` still reports red in the CI status (so the upstream issue stays visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)