### PR TITLE
test: revert short-history p2 heading to h3 (corrects #598 misread)

### DIFF
--- a/tests/specs/departmenthistory/prod_shorthistory_titles.spec.js
+++ b/tests/specs/departmenthistory/prod_shorthistory_titles.spec.js
@@ -15,7 +15,7 @@ const subpages = [
   {
     name: 'p2',
     link: 'departmenthistory/short-history/foundations',
-    level:'h2',
+    level:'h3',
     title: 'Foundations of Foreign Affairs, 1775-1823'
   },
   {


### PR DESCRIPTION
## Summary
- Revert `tests/specs/departmenthistory/prod_shorthistory_titles.spec.js` p2 `level` from `h2` back to `h3`.
- Fixes the 3.11.3 Jenkins regression: `element ("#content-inner h2") still not existing after 10000ms`.

## Why
PR #598 changed p2's level pin from `h3` to `h2` based on a misread of the rendered HTML. I used a flat `grep`/`awk` over the whole response, which over-matched past `#content-inner`'s closing tag and picked up `<h2 class="tei-head7">` elements from the sibling `<aside>` sidebar.

Re-parsing both servers with proper HTML scope (balanced div matching via Python's HTMLParser) shows the same structure inside `#content-inner` on both:

```
<h3>Foundations of Foreign Affairs,
<h4>Contents
```

There is no `<h2>` inside `#content-inner` on either localhost (HSG_ENV=production build) or the prod-preview3 Jenkins target. That's why 3.11.3's Jenkins run failed — the new pin had nothing to match.

The original p2 Jenkins failure that motivated #598 was a cold-cache timing flake, already mitigated by the `waitForExist` wrapper added in 33b5890b. The `level: 'h3'` was the correct pin all along.

## Test plan
- [x] Local `HSG_ENV=production` build + redeploy + `wdio … --spec tests/specs/departmenthistory/prod_shorthistory_titles.spec.js` → 3 passing in 1.2s.
- [ ] Jenkins `hsg-prod-preview3` rerun after merge — should also pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)