### PR TITLE
feat(search): reject malicious query parameters with HTTP 400

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -4,6 +4,8 @@ declare namespace exist="http://exist.sourceforge.net/NS/exist";
 declare namespace map="http://www.w3.org/2005/xpath-functions/map";
 declare namespace request="http://exist-db.org/xquery/request";
 
+import module namespace query-guard="http://history.state.gov/ns/site/hsg/query-guard" at "modules/query-guard.xqm";
+
 declare variable $exist:path external;
 declare variable $exist:resource external;
 declare variable $exist:controller external;
@@ -39,6 +41,11 @@ declare function local:maybe-set-if-modified-since($ims-header-value as xs:strin
 declare function local:serve-not-found-page() as element() {
     response:set-status-code(404),
     local:render-page("error-page-404.xml")
+};
+
+declare function local:serve-bad-request-page() as element() {
+    response:set-status-code(400),
+    local:render-page("error-page-400.xml")
 };
 
 declare variable $local:view-module-url := $exist:controller || "/modules/view.xql";
@@ -689,21 +696,26 @@ else switch($path-parts[1])
     case 'search' return
         switch (string($path-parts[2]))
             case '' return
-                let $show-search-results := fold-left(("q", "start-date", "end-date"), false(), function($result, $next-parameter-name) {
-                    let $values := request:get-parameter($next-parameter-name, ()) ! normalize-space()[. ne ""]
-                    return $result or exists($values)
-                })
-                (: If a search query is present, show the results template :)
-                let $page :=
-                    if ($show-search-results) then
-                        'search/search-result.xml'
-                    else
-                        'search/search-landing.xml'
-                return
-                    local:render-page($page, map{
-                        "suppress-sitewide-search-field": "true",
-                        "publication-id": "search"
+                (: reject malicious search queries (documented operators like " + - ( ) * ? ~ still pass) :)
+                if (query-guard:check(request:get-parameter("q", ()))) then (
+                    local:serve-bad-request-page()
+                ) else (
+                    let $show-search-results := fold-left(("q", "start-date", "end-date"), false(), function($result, $next-parameter-name) {
+                        let $values := request:get-parameter($next-parameter-name, ()) ! normalize-space()[. ne ""]
+                        return $result or exists($values)
                     })
+                    (: If a search query is present, show the results template :)
+                    let $page :=
+                        if ($show-search-results) then
+                            'search/search-result.xml'
+                        else
+                            'search/search-landing.xml'
+                    return
+                        local:render-page($page, map{
+                            "suppress-sitewide-search-field": "true",
+                            "publication-id": "search"
+                        })
+                )
             case 'tips' return
                 local:render-page('search/tips.xml', map{ "publication-id": "app" })
             default return

--- a/modules/query-guard.xqm
+++ b/modules/query-guard.xqm
@@ -1,0 +1,100 @@
+xquery version "3.1";
+
+(:~
+ : Query guard — rejects malicious or malformed values of the search `q`
+ : parameter before they reach the query pipeline.
+ :
+ : The site's search deliberately exposes Lucene query syntax to users (phrases,
+ : booleans, wildcards, proximity — see pages/search/tips.xml), so the documented
+ : operators " + - ( ) * ? ~ and the AND/OR/NOT keywords must pass through
+ : untouched. This module only blocks input that can never be part of a
+ : legitimate query:
+ :   1. rejected characters — leftover percent-encoding, control characters, and
+ :      the Lucene metacharacters that are NOT documented as features; and
+ :   2. SQL-injection signatures — inert against our Lucene backend, but rejected
+ :      to keep obvious attack traffic out of the query pipeline and the logs.
+ :
+ : The controller calls a single entry point, query-guard:check(), so the reject
+ : policy lives entirely here.
+ :
+ : Note: eXist's fn:matches uses the W3C XPath regex grammar. It supports the
+ : \p{...} category escapes but has NO \b word-boundary escape and cannot express
+ : a reference to codepoint 0, so control characters are matched with \p{Cc} and
+ : word boundaries with (^|\W) / (\W|$).
+ :)
+module namespace query-guard = "http://history.state.gov/ns/site/hsg/query-guard";
+
+(:~
+ : Characters that make a `q` value invalid:
+ :   %                    leftover percent-encoding — request parameters are
+ :                        already URL-decoded, so a literal % signals a malformed
+ :                        or double-encoded request
+ :   ! : ^ / \ [ ] { }    Lucene metacharacters not exposed as search features
+ :   \p{Cc}               ASCII/Unicode control characters
+ : The documented operators (" + - ( ) * ? ~) are intentionally absent so that
+ : phrase, boolean, wildcard, and proximity searches keep working.
+ :)
+declare %private variable $query-guard:INVALID-CHARS-REGEX as xs:string :=
+    "[%!:/{}\[\]\^\\\p{Cc}]";
+
+(:~
+ : Signatures of SQL-injection probes that slip past the character blacklist: a
+ : payload such as
+ :   gMxR' UNION ALL SELECT NULL,NULL,...-- -
+ : uses only letters, digits, spaces, commas, apostrophes and hyphens, none of
+ : which are rejected characters. The site has no SQL backend (searches run
+ : against Lucene, so these can never actually inject), but rejecting them keeps
+ : obvious attack traffic out of the query pipeline and the logs.
+ :
+ : This is a deliberately heuristic, case-insensitive match. It targets shapes
+ : that do not occur in ordinary history queries:
+ :   union [all] select        classic UNION-based injection
+ :   ; select|insert|drop|...   stacked statements
+ :   or/and <n> = <n>           boolean tautologies (e.g. OR 1=1)
+ :   sleep(/benchmark(/...      time-based blind injection
+ :   --<space or end>           inline SQL comment terminator
+ : Trade-off: an unusual literal search like "Union Select Committee" could trip
+ : the first rule. That is accepted as the cost of a simple, readable rule.
+ :)
+declare %private variable $query-guard:SQL-INJECTION-REGEX as xs:string :=
+    string-join(
+        (
+            "(^|\W)union\s+(all\s+)?select(\W|$)",
+            ";\s*(select|insert|update|delete|drop|alter|create|truncate|exec|union)(\W|$)",
+            "(^|\W)(or|and)\s+\d+\s*=\s*\d+",
+            "(^|\W)(sleep|benchmark|pg_sleep|waitfor\s+delay)\s*\(",
+            "(^|\s)--(\s|$)"
+        ),
+        "|"
+    );
+
+(:~
+ : Does any `q` value contain a character we refuse to pass to Lucene?
+ : @param $q the raw (already URL-decoded) `q` value(s); a `q` parameter may be
+ :           repeated, so this accepts a sequence
+ : @return true if any value contains a rejected character
+ :)
+declare function query-guard:has-invalid-characters($q as xs:string*) as xs:boolean {
+    some $value in $q satisfies matches($value, $query-guard:INVALID-CHARS-REGEX)
+};
+
+(:~
+ : Does any `q` value look like a SQL-injection probe? Matching is
+ : case-insensitive.
+ : @param $q the raw (already URL-decoded) `q` value(s)
+ : @return true if any value matches a known injection signature
+ :)
+declare function query-guard:looks-like-sql-injection($q as xs:string*) as xs:boolean {
+    some $value in $q satisfies matches($value, $query-guard:SQL-INJECTION-REGEX, "i")
+};
+
+(:~
+ : Single entry point: should this `q` value be rejected with HTTP 400?
+ : Combines every reject rule so callers need only this one function.
+ : @param $q the raw (already URL-decoded) `q` value(s)
+ : @return true if the query is a malicious or malformed payload to reject
+ :)
+declare function query-guard:check($q as xs:string*) as xs:boolean {
+    query-guard:has-invalid-characters($q)
+    or query-guard:looks-like-sql-injection($q)
+};

--- a/modules/query-guard.xqm
+++ b/modules/query-guard.xqm
@@ -1,86 +1,76 @@
 xquery version "3.1";
 
 (:~
- : Query guard — rejects malicious or malformed values of the search `q`
- : parameter before they reach the query pipeline.
+ : Query guard — rejects search `q` values that look like SQL-injection probes.
  :
- : The site's search deliberately exposes Lucene query syntax to users (phrases,
- : booleans, wildcards, proximity — see pages/search/tips.xml), so the documented
- : operators " + - ( ) * ? ~ and the AND/OR/NOT keywords must pass through
- : untouched. This module only blocks input that can never be part of a
- : legitimate query:
- :   1. rejected characters — leftover percent-encoding, control characters, and
- :      the Lucene metacharacters that are NOT documented as features; and
- :   2. SQL-injection signatures — inert against our Lucene backend, but rejected
- :      to keep obvious attack traffic out of the query pipeline and the logs.
+ : The site has no SQL backend (searches run against Lucene), so these payloads
+ : can never actually inject; a missed one is inert. The guard exists only to
+ : keep obvious automated attack traffic out of the query pipeline and the logs,
+ : and the controller turns a positive match into an HTTP 400.
  :
- : The controller calls a single entry point, query-guard:check(), so the reject
- : policy lives entirely here.
+ : Because a false negative is harmless but a false positive turns a legitimate
+ : history search into an error page, the patterns below are deliberately biased
+ : toward NOT firing: each targets a shape that effectively never occurs in
+ : ordinary prose queries. Notably we do NOT flag a bare "union select" (cf.
+ : "European Union Select Committee") or a lone "--" dash (cf. "Nixon -- Kissinger").
  :
- : Note: eXist's fn:matches uses the W3C XPath regex grammar. It supports the
- : \p{...} category escapes but has NO \b word-boundary escape and cannot express
- : a reference to codepoint 0, so control characters are matched with \p{Cc} and
- : word boundaries with (^|\W) / (\W|$).
+ : Unsupported Lucene metacharacters (! : ^ / \ [ ] { }) are NOT handled here —
+ : they are escaped at query-build time in search.xqm so they search literally.
+ :
+ : Note: eXist's fn:matches uses the W3C XPath regex grammar, which has no \b
+ : word-boundary escape, so boundaries are written as (^|\W) ... (\W|$).
  :)
 module namespace query-guard = "http://history.state.gov/ns/site/hsg/query-guard";
 
 (:~
- : Characters that make a `q` value invalid:
- :   %                    leftover percent-encoding — request parameters are
- :                        already URL-decoded, so a literal % signals a malformed
- :                        or double-encoded request
- :   ! : ^ / \ [ ] { }    Lucene metacharacters not exposed as search features
- :   \p{Cc}               ASCII/Unicode control characters
- : The documented operators (" + - ( ) * ? ~) are intentionally absent so that
- : phrase, boolean, wildcard, and proximity searches keep working.
+ : Maximum total length (summed over all values) of the `q` parameter the guard
+ : will inspect. The guard is hot code: it runs on unauthenticated input ahead of
+ : the search, so its cost must not scale with attacker input. Real search queries
+ : are short; anything longer is junk or an attempt to make the guard (and the
+ : downstream Lucene parse / cache / render) do unbounded work, so check() rejects
+ : it up front. fn:matches over these patterns is linear — no catastrophic
+ : backtracking — so this cap is defence-in-depth against input *size*, bounding
+ : the work to O(MAX). Tune freely; 1000 chars is already far beyond any real query.
  :)
-declare %private variable $query-guard:INVALID-CHARS-REGEX as xs:string :=
-    "[%!:/{}\[\]\^\\\p{Cc}]";
+declare variable $query-guard:MAX-QUERY-LENGTH as xs:integer := 1000;
 
 (:~
- : Signatures of SQL-injection probes that slip past the character blacklist: a
- : payload such as
- :   gMxR' UNION ALL SELECT NULL,NULL,...-- -
- : uses only letters, digits, spaces, commas, apostrophes and hyphens, none of
- : which are rejected characters. The site has no SQL backend (searches run
- : against Lucene, so these can never actually inject), but rejecting them keeps
- : obvious attack traffic out of the query pipeline and the logs.
- :
- : This is a deliberately heuristic, case-insensitive match. It targets shapes
- : that do not occur in ordinary history queries:
- :   union [all] select        classic UNION-based injection
- :   ; select|insert|drop|...   stacked statements
- :   or/and <n> = <n>           boolean tautologies (e.g. OR 1=1)
- :   sleep(/benchmark(/...      time-based blind injection
- :   --<space or end>           inline SQL comment terminator
- : Trade-off: an unusual literal search like "Union Select Committee" could trip
- : the first rule. That is accepted as the cost of a simple, readable rule.
+ : SQL-injection signatures, joined into one case-insensitive pattern. Each
+ : alternative is chosen to be extremely unlikely in a real history query:
+ :   union all select                  UNION-based injection (ALL makes it safe
+ :                                      against "European Union select ...")
+ :   union select <sql-token>          UNION-based injection whose column list
+ :                                      starts with null / a digit / * / @ /
+ :                                      concat / distinct / from (never a plain
+ :                                      word like "Committee")
+ :   or/and <n> = <n>                  boolean tautology (e.g. OR 1=1)
+ :   sleep(/benchmark(/pg_sleep( <n>   time-based blind injection (numeric arg,
+ :                                      so ordinary "... asleep (" does not fire)
+ :   waitfor delay                     MSSQL time-based injection
+ :   ; <sql-verb>                      stacked statement
+ :   null , null                       UNION column-count padding (the tell-tale
+ :                                     NULL,NULL,... list); requires two
+ :                                     comma-separated NULLs so history terms like
+ :                                     "Nullification" and "annulment" are safe
  :)
 declare %private variable $query-guard:SQL-INJECTION-REGEX as xs:string :=
     string-join(
         (
-            "(^|\W)union\s+(all\s+)?select(\W|$)",
-            ";\s*(select|insert|update|delete|drop|alter|create|truncate|exec|union)(\W|$)",
+            "(^|\W)union\s+all\s+select(\W|$)",
+            "(^|\W)union\s+select\s+(null(\W|$)|distinct(\W|$)|top(\W|$)|from(\W|$)|concat\W|\d|\*|@)",
             "(^|\W)(or|and)\s+\d+\s*=\s*\d+",
-            "(^|\W)(sleep|benchmark|pg_sleep|waitfor\s+delay)\s*\(",
-            "(^|\s)--(\s|$)"
+            "(^|\W)(sleep|benchmark|pg_sleep)\s*\(\s*\d",
+            "(^|\W)waitfor\s+delay(\W|$)",
+            ";\s*(select|insert|update|delete|drop|alter|create|truncate|exec)(\W|$)",
+            "(^|\W)null\s*,\s*null"
         ),
         "|"
     );
 
 (:~
- : Does any `q` value contain a character we refuse to pass to Lucene?
- : @param $q the raw (already URL-decoded) `q` value(s); a `q` parameter may be
- :           repeated, so this accepts a sequence
- : @return true if any value contains a rejected character
- :)
-declare function query-guard:has-invalid-characters($q as xs:string*) as xs:boolean {
-    some $value in $q satisfies matches($value, $query-guard:INVALID-CHARS-REGEX)
-};
-
-(:~
  : Does any `q` value look like a SQL-injection probe? Matching is
- : case-insensitive.
+ : case-insensitive. A `q` parameter may be repeated, so this accepts a sequence
+ : and returns true if any single value matches.
  : @param $q the raw (already URL-decoded) `q` value(s)
  : @return true if any value matches a known injection signature
  :)
@@ -89,12 +79,18 @@ declare function query-guard:looks-like-sql-injection($q as xs:string*) as xs:bo
 };
 
 (:~
- : Single entry point: should this `q` value be rejected with HTTP 400?
- : Combines every reject rule so callers need only this one function.
+ : Single entry point for the controller: should this `q` value be rejected with
+ : HTTP 400? Currently the only reject rule is the SQL-injection heuristic;
+ : keeping this thin wrapper means the controller need not know that.
  : @param $q the raw (already URL-decoded) `q` value(s)
- : @return true if the query is a malicious or malformed payload to reject
+ : @return true if the query must be rejected
  :)
 declare function query-guard:check($q as xs:string*) as xs:boolean {
-    query-guard:has-invalid-characters($q)
-    or query-guard:looks-like-sql-injection($q)
+    (: Gate on length FIRST, via if/then/else rather than `or`, so an oversized q
+       is rejected without fn:matches ever scanning unbounded attacker input.
+       (XQuery does not guarantee `or` short-circuits, so the gate must be explicit.) :)
+    if (sum($q ! string-length(.)) gt $query-guard:MAX-QUERY-LENGTH) then
+        true()
+    else
+        query-guard:looks-like-sql-injection($q)
 };

--- a/modules/search.xqm
+++ b/modules/search.xqm
@@ -20,6 +20,22 @@ declare namespace frus="http://history.state.gov/frus/ns/1.0";
 
 declare variable $search:MAX_HITS_SHOWN := 1000;
 
+(:~
+ : Lucene special characters that the site does not expose as search features.
+ : They are backslash-escaped before the query is handed to ft:query (see
+ : search:escape-unsupported-characters) so that, e.g., "title:secret" is
+ : searched as a literal term — yielding zero results — instead of being parsed
+ : as Lucene field syntax or raising a query-parser error.
+ :
+ : The documented operators (" + - ( ) * ? ~ and the AND/OR/NOT keywords) are
+ : intentionally absent from this set so that phrase, boolean, wildcard, and
+ : proximity searches keep working.
+ :
+ : Note: eXist's fn:replace uses the W3C XPath regex grammar; inside the
+ : character class the backslash, brackets and caret are themselves escaped.
+ :)
+declare variable $search:UNSUPPORTED-LUCENE-CHARS as xs:string := "[/\\!:\^\[\]{}]";
+
 declare variable $search:ft-query-options := map {
     "default-operator": "and",
     "phrase-slop": 0,
@@ -690,7 +706,22 @@ declare function search:sort($hits as element()*, $sort-by as xs:string) {
                 $hit
 };
 
-declare %private function search:prepare-query($sections as xs:string*, $volume-ids as xs:string*, 
+(:~
+ : Escape the Lucene special characters we do not support as features so they
+ : are searched literally instead of altering the query or breaking the parser.
+ : @param $query the (already normalized) keyword query
+ : @return the query with $search:UNSUPPORTED-LUCENE-CHARS backslash-escaped
+ :)
+declare %private function search:escape-unsupported-characters($query as xs:string?) as xs:string? {
+    if (exists($query)) then
+        (: the capturing group lets the replacement prepend "\" to each match;
+           XPath fn:replace has no $0 for the whole match :)
+        replace($query, "(" || $search:UNSUPPORTED-LUCENE-CHARS || ")", "\\$1")
+    else
+        ()
+};
+
+declare %private function search:prepare-query($sections as xs:string*, $volume-ids as xs:string*,
     $query as xs:string?, $range-start as xs:dateTime?, $range-end as xs:dateTime?) {
     let $category := 
         for $section in $sections
@@ -715,7 +746,7 @@ declare %private function search:prepare-query($sections as xs:string*, $volume-
     let $is-date-query := exists($range-start)
     let $is-keyword-query := exists($query)
 
-    let $fulltext-query := if (exists($query)) then 'hsg-fulltext:(' || $query || ') ' else ()
+    let $fulltext-query := if (exists($query)) then 'hsg-fulltext:(' || search:escape-unsupported-characters($query) || ') ' else ()
 
     (: translate date ranges to the form used by Lucene index, cf. frus/volumes.xconf :)
     let $range-start := translate($range-start, ':-', '')

--- a/modules/tests/test-query-guard.xqm
+++ b/modules/tests/test-query-guard.xqm
@@ -1,0 +1,192 @@
+xquery version "3.1";
+
+module namespace x="http://history.state.gov/ns/site/hsg/tests/test-query-guard";
+
+import module namespace query-guard="http://history.state.gov/ns/site/hsg/query-guard" at "../query-guard.xqm";
+
+declare namespace test="http://exist-db.org/xquery/xqsuite";
+
+(: ---- valid queries: plain terms and every documented Lucene operator ---- :)
+
+declare
+    %test:assertFalse
+function x:plain-word() {
+    query-guard:has-invalid-characters("Washington")
+};
+
+declare
+    %test:assertFalse
+function x:phrase-with-space() {
+    query-guard:has-invalid-characters("United Nations")
+};
+
+declare
+    (: documented on the search tips page: phrases, booleans, wildcards, proximity, grouping :)
+    %test:assertFalse
+function x:documented-phrase-quotes() {
+    query-guard:has-invalid-characters('"peaceful nuclear"')
+};
+
+declare
+    %test:assertFalse
+function x:documented-plus-minus() {
+    query-guard:has-invalid-characters("+law -sea")
+};
+
+declare
+    %test:assertFalse
+function x:documented-grouping() {
+    query-guard:has-invalid-characters('(Guatemala OR "El Salvador") AND Belize')
+};
+
+declare
+    %test:assertFalse
+function x:documented-wildcards() {
+    query-guard:has-invalid-characters("te?t Vietna*")
+};
+
+declare
+    %test:assertFalse
+function x:documented-proximity() {
+    query-guard:has-invalid-characters('"Cuba submarine"~10')
+};
+
+declare
+    %test:assertFalse
+function x:accented-characters() {
+    query-guard:has-invalid-characters("café Málaga")
+};
+
+declare
+    %test:assertFalse
+function x:empty-sequence() {
+    query-guard:has-invalid-characters(())
+};
+
+(: ---- invalid queries: percent-encoding, control chars, undocumented metachars ---- :)
+
+declare
+    %test:assertTrue
+function x:percent-encoding() {
+    query-guard:has-invalid-characters("te%20st")
+};
+
+declare
+    %test:assertTrue
+function x:bang() {
+    query-guard:has-invalid-characters("Washington!")
+};
+
+declare
+    %test:assertTrue
+function x:colon-field-injection() {
+    query-guard:has-invalid-characters("hsg-category:frus")
+};
+
+declare
+    %test:assertTrue
+function x:caret-boost() {
+    query-guard:has-invalid-characters("term^2")
+};
+
+declare
+    %test:assertTrue
+function x:forward-slash-regex() {
+    query-guard:has-invalid-characters("/regex/")
+};
+
+declare
+    %test:assertTrue
+function x:backslash() {
+    query-guard:has-invalid-characters("a\b")
+};
+
+declare
+    %test:assertTrue
+function x:square-brackets-range() {
+    query-guard:has-invalid-characters("[1946 TO 1947]")
+};
+
+declare
+    %test:assertTrue
+function x:curly-brackets-range() {
+    query-guard:has-invalid-characters("{a TO b}")
+};
+
+declare
+    %test:assertTrue
+function x:control-character() {
+    query-guard:has-invalid-characters("line1&#x0A;line2")
+};
+
+declare
+    (: any single invalid value in a repeated q parameter fails the whole set :)
+    %test:assertTrue
+function x:one-of-many-invalid() {
+    query-guard:has-invalid-characters(("valid", "in%20valid"))
+};
+
+(: ---- SQL-injection heuristic ---- :)
+
+declare
+    %test:assertTrue
+function x:sqli-union-select() {
+    query-guard:looks-like-sql-injection("gMxR' UNION ALL SELECT NULL,NULL,NULL-- -")
+};
+
+declare
+    %test:assertTrue
+function x:sqli-tautology() {
+    query-guard:looks-like-sql-injection("1 OR 1=1")
+};
+
+declare
+    %test:assertTrue
+function x:sqli-stacked-statement() {
+    query-guard:looks-like-sql-injection("x; DROP TABLE users")
+};
+
+declare
+    %test:assertTrue
+function x:sqli-time-based() {
+    query-guard:looks-like-sql-injection("1) OR sleep(5)")
+};
+
+declare
+    (: "Union" and "Select Committee" are legitimate history terms, but not adjacent as "union select" :)
+    %test:assertFalse
+function x:sqli-false-positive-soviet-union() {
+    query-guard:looks-like-sql-injection("Soviet Union")
+};
+
+declare
+    %test:assertFalse
+function x:sqli-false-positive-select-committee() {
+    query-guard:looks-like-sql-injection("Select Committee on Assassinations")
+};
+
+declare
+    %test:assertFalse
+function x:sqli-false-positive-hyphenated() {
+    query-guard:looks-like-sql-injection("Berlin-Baghdad railway")
+};
+
+(: ---- check(): the single controller entry point ---- :)
+
+declare
+    %test:assertFalse
+function x:check-valid-query() {
+    query-guard:check('"peaceful nuclear" +treaty')
+};
+
+declare
+    %test:assertTrue
+function x:check-rejects-invalid-characters() {
+    query-guard:check("hsg-category:frus")
+};
+
+declare
+    %test:assertTrue
+function x:check-rejects-sql-injection() {
+    query-guard:check("gMxR' UNION ALL SELECT NULL,NULL-- -")
+};

--- a/modules/tests/test-query-guard.xqm
+++ b/modules/tests/test-query-guard.xqm
@@ -6,132 +6,18 @@ import module namespace query-guard="http://history.state.gov/ns/site/hsg/query-
 
 declare namespace test="http://exist-db.org/xquery/xqsuite";
 
-(: ---- valid queries: plain terms and every documented Lucene operator ---- :)
-
-declare
-    %test:assertFalse
-function x:plain-word() {
-    query-guard:has-invalid-characters("Washington")
-};
-
-declare
-    %test:assertFalse
-function x:phrase-with-space() {
-    query-guard:has-invalid-characters("United Nations")
-};
-
-declare
-    (: documented on the search tips page: phrases, booleans, wildcards, proximity, grouping :)
-    %test:assertFalse
-function x:documented-phrase-quotes() {
-    query-guard:has-invalid-characters('"peaceful nuclear"')
-};
-
-declare
-    %test:assertFalse
-function x:documented-plus-minus() {
-    query-guard:has-invalid-characters("+law -sea")
-};
-
-declare
-    %test:assertFalse
-function x:documented-grouping() {
-    query-guard:has-invalid-characters('(Guatemala OR "El Salvador") AND Belize')
-};
-
-declare
-    %test:assertFalse
-function x:documented-wildcards() {
-    query-guard:has-invalid-characters("te?t Vietna*")
-};
-
-declare
-    %test:assertFalse
-function x:documented-proximity() {
-    query-guard:has-invalid-characters('"Cuba submarine"~10')
-};
-
-declare
-    %test:assertFalse
-function x:accented-characters() {
-    query-guard:has-invalid-characters("café Málaga")
-};
-
-declare
-    %test:assertFalse
-function x:empty-sequence() {
-    query-guard:has-invalid-characters(())
-};
-
-(: ---- invalid queries: percent-encoding, control chars, undocumented metachars ---- :)
+(: ---- SQL-injection probes: must be flagged ---- :)
 
 declare
     %test:assertTrue
-function x:percent-encoding() {
-    query-guard:has-invalid-characters("te%20st")
-};
-
-declare
-    %test:assertTrue
-function x:bang() {
-    query-guard:has-invalid-characters("Washington!")
-};
-
-declare
-    %test:assertTrue
-function x:colon-field-injection() {
-    query-guard:has-invalid-characters("hsg-category:frus")
-};
-
-declare
-    %test:assertTrue
-function x:caret-boost() {
-    query-guard:has-invalid-characters("term^2")
-};
-
-declare
-    %test:assertTrue
-function x:forward-slash-regex() {
-    query-guard:has-invalid-characters("/regex/")
-};
-
-declare
-    %test:assertTrue
-function x:backslash() {
-    query-guard:has-invalid-characters("a\b")
-};
-
-declare
-    %test:assertTrue
-function x:square-brackets-range() {
-    query-guard:has-invalid-characters("[1946 TO 1947]")
-};
-
-declare
-    %test:assertTrue
-function x:curly-brackets-range() {
-    query-guard:has-invalid-characters("{a TO b}")
-};
-
-declare
-    %test:assertTrue
-function x:control-character() {
-    query-guard:has-invalid-characters("line1&#x0A;line2")
-};
-
-declare
-    (: any single invalid value in a repeated q parameter fails the whole set :)
-    %test:assertTrue
-function x:one-of-many-invalid() {
-    query-guard:has-invalid-characters(("valid", "in%20valid"))
-};
-
-(: ---- SQL-injection heuristic ---- :)
-
-declare
-    %test:assertTrue
-function x:sqli-union-select() {
+function x:sqli-union-all-select() {
     query-guard:looks-like-sql-injection("gMxR' UNION ALL SELECT NULL,NULL,NULL-- -")
+};
+
+declare
+    %test:assertTrue
+function x:sqli-union-select-columns() {
+    query-guard:looks-like-sql-injection("' union select 1,2,3 from users")
 };
 
 declare
@@ -148,27 +34,106 @@ function x:sqli-stacked-statement() {
 
 declare
     %test:assertTrue
-function x:sqli-time-based() {
+function x:sqli-time-based-sleep() {
     query-guard:looks-like-sql-injection("1) OR sleep(5)")
 };
 
 declare
-    (: "Union" and "Select Committee" are legitimate history terms, but not adjacent as "union select" :)
+    %test:assertTrue
+function x:sqli-time-based-waitfor() {
+    query-guard:looks-like-sql-injection("1; waitfor delay '0:0:5'")
+};
+
+declare
+    (: the tell-tale UNION column-count padding, even without a nearby "select" :)
+    %test:assertTrue
+function x:sqli-null-column-list() {
+    query-guard:looks-like-sql-injection("foo NULL,NULL,NULL bar")
+};
+
+(: ---- legitimate history queries: must NOT be flagged ---- :)
+(: These are the accidental-flag cases the review asked us to double-check. :)
+
+declare
     %test:assertFalse
-function x:sqli-false-positive-soviet-union() {
+function x:ok-soviet-union() {
     query-guard:looks-like-sql-injection("Soviet Union")
 };
 
 declare
+    (: "union" and "Select Committee" adjacent — flagged by a naive "union select" rule :)
     %test:assertFalse
-function x:sqli-false-positive-select-committee() {
-    query-guard:looks-like-sql-injection("Select Committee on Assassinations")
+function x:ok-european-union-select-committee() {
+    query-guard:looks-like-sql-injection("European Union Select Committee")
 };
 
 declare
     %test:assertFalse
-function x:sqli-false-positive-hyphenated() {
+function x:ok-select-committee() {
+    query-guard:looks-like-sql-injection("Select Committee on Assassinations")
+};
+
+declare
+    (: double dash as a typographic separator — flagged by a naive "--" comment rule :)
+    %test:assertFalse
+function x:ok-double-dash-separator() {
+    query-guard:looks-like-sql-injection("Nixon -- Kissinger relations")
+};
+
+declare
+    (: "sleep (" in prose — flagged by a naive "sleep(" rule :)
+    %test:assertFalse
+function x:ok-sleep-in-prose() {
+    query-guard:looks-like-sql-injection("fell asleep (finally) in 1945")
+};
+
+declare
+    %test:assertFalse
+function x:ok-and-keyword() {
+    query-guard:looks-like-sql-injection("arms control and disarmament")
+};
+
+declare
+    %test:assertFalse
+function x:ok-or-keyword() {
+    query-guard:looks-like-sql-injection("Guatemala OR El Salvador")
+};
+
+declare
+    %test:assertFalse
+function x:ok-drop-without-semicolon() {
+    query-guard:looks-like-sql-injection("a sharp drop in relations")
+};
+
+declare
+    %test:assertFalse
+function x:ok-hyphenated() {
     query-guard:looks-like-sql-injection("Berlin-Baghdad railway")
+};
+
+declare
+    (: "null" appears inside Nullification / annulment; the rule needs two commas'd NULLs :)
+    %test:assertFalse
+function x:ok-nullification() {
+    query-guard:looks-like-sql-injection("Nullification Crisis of 1832")
+};
+
+declare
+    %test:assertFalse
+function x:ok-annulment() {
+    query-guard:looks-like-sql-injection("annulment of the marriage")
+};
+
+declare
+    %test:assertFalse
+function x:ok-documented-operators() {
+    query-guard:looks-like-sql-injection('"peaceful nuclear" +treaty -weapon')
+};
+
+declare
+    %test:assertFalse
+function x:ok-empty-sequence() {
+    query-guard:looks-like-sql-injection(())
 };
 
 (: ---- check(): the single controller entry point ---- :)
@@ -181,12 +146,27 @@ function x:check-valid-query() {
 
 declare
     %test:assertTrue
-function x:check-rejects-invalid-characters() {
-    query-guard:check("hsg-category:frus")
+function x:check-rejects-sql-injection() {
+    query-guard:check("gMxR' UNION ALL SELECT NULL,NULL-- -")
 };
 
 declare
+    (: any single injection value in a repeated q parameter rejects the whole set :)
     %test:assertTrue
-function x:check-rejects-sql-injection() {
-    query-guard:check("gMxR' UNION ALL SELECT NULL,NULL-- -")
+function x:check-rejects-one-of-many() {
+    query-guard:check(("Washington", "1 OR 1=1"))
+};
+
+declare
+    (: DoS guard: an over-length q is rejected up front, bounding regex work :)
+    %test:assertTrue
+function x:check-rejects-oversized-query() {
+    query-guard:check(string-join(for $i in 1 to 2000 return "a", ""))
+};
+
+declare
+    (: a normal-length clean query is not rejected by the length gate :)
+    %test:assertFalse
+function x:check-allows-normal-length-query() {
+    query-guard:check("the Cuban missile crisis and Soviet-American relations")
 };

--- a/pages/error-page-400.xml
+++ b/pages/error-page-400.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<div data-template="templates:surround" data-template-at="content"
+    data-template-with="templates/site.xml">
+    <div data-template="app:fix-links">
+        <h1>Invalid search query</h1>
+        <p>Your search query contained characters that cannot be processed.
+            Please remove any special characters and
+            <a href="$app/search">try your search again</a>.
+            See the <a href="$app/search/tips">search tips</a> for supported
+            search syntax.</p>
+    </div>
+</div>

--- a/tests/cypress/e2e/search/malicious-query.cy.js
+++ b/tests/cypress/e2e/search/malicious-query.cy.js
@@ -1,0 +1,63 @@
+/**
+ * Search query validation – malicious `q` values must be rejected with HTTP 400.
+ *
+ * The controller calls query-guard:check() (modules/query-guard.xqm) and serves
+ * error-page-400.xml with a 400 status when the `q` parameter contains
+ * characters we never pass to Lucene (% ! : / \ [ ] { } ^ and ASCII/Unicode
+ * control characters) or looks like a SQL-injection probe. Documented operators
+ * (" + - ( ) * ? ~) are intentionally still allowed – see the regression guard
+ * at the bottom.
+ *
+ * @see modules/query-guard.xqm (query-guard:check)
+ * @see controller.xql (case 'search' -> local:serve-bad-request-page)
+ */
+
+// Each value contains at least one rejected metacharacter.
+const maliciousQueries = [
+  'title:secret',     // : – Lucene field-scoping / injection
+  '../../etc/passwd', // / – path traversal
+  'boost^10',         // ^ – boost metacharacter
+  '[a TO z]',         // [ ] – range metacharacter
+  '{malformed}',      // { } – metacharacter
+  '100%'              // % – leftover / double percent-encoding
+]
+
+describe('Search: malicious queries are rejected with 400', function () {
+  maliciousQueries.forEach(function (q) {
+    it(`responds 400 for q="${q}"`, function () {
+      cy.request({ url: 'search', qs: { q }, failOnStatusCode: false })
+        .its('status')
+        .should('eq', 400)
+    })
+  })
+
+  it('renders the "Invalid search query" page for a rejected query', function () {
+    cy.visit('search', { qs: { q: 'title:secret' }, failOnStatusCode: false })
+    cy.get('h1').should('contain', 'Invalid search query')
+  })
+
+  // UNION-based SQL-injection probe. It contains no blacklisted characters
+  // (only ' , - and spaces once URL-decoded), so it is caught by the separate
+  // SQL-injection heuristic inside query-guard:check(), not the character check.
+  // Original request:
+  //   GET /exist/apps/hsg-shell/search?q=gMxR%27%20UNION%20ALL%20SELECT%20NULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL--%20-
+  it('responds 400 for a UNION-based SQL injection probe', function () {
+    const q = "gMxR' UNION ALL SELECT NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL-- -"
+    cy.request({ url: 'search', qs: { q }, failOnStatusCode: false })
+      .its('status')
+      .should('eq', 400)
+  })
+})
+
+describe('Search: documented operators are still allowed', function () {
+  // Regression guard: legitimate Lucene syntax must NOT trigger the 400.
+  it('responds 200 for a query using documented operators', function () {
+    cy.request({
+      url: 'search',
+      qs: { q: '"United Nations" +Washington -Berlin' },
+      failOnStatusCode: false
+    })
+      .its('status')
+      .should('eq', 200)
+  })
+})

--- a/tests/cypress/e2e/search/malicious-query.cy.js
+++ b/tests/cypress/e2e/search/malicious-query.cy.js
@@ -1,29 +1,51 @@
 /**
- * Search query validation – malicious `q` values must be rejected with HTTP 400.
+ * Search query handling for hostile / malformed `q` values.
  *
- * The controller calls query-guard:check() (modules/query-guard.xqm) and serves
- * error-page-400.xml with a 400 status when the `q` parameter contains
- * characters we never pass to Lucene (% ! : / \ [ ] { } ^ and ASCII/Unicode
- * control characters) or looks like a SQL-injection probe. Documented operators
- * (" + - ( ) * ? ~) are intentionally still allowed – see the regression guard
- * at the bottom.
+ * Two different behaviours, by design:
+ *  - Unsupported Lucene metacharacters (! : ^ / \ [ ] { }) are ESCAPED and
+ *    searched literally, so they return a normal 200 results page — never a 400.
+ *    Escaping happens at query-build time in search.xqm
+ *    (search:escape-unsupported-characters), not in the controller.
+ *  - SQL-injection probes ARE rejected with HTTP 400 by query-guard:check()
+ *    in the controller, which serves error-page-400.xml.
+ *  - Documented Lucene operators (" + - ( ) * ? ~) always pass through.
  *
+ * @see modules/search.xqm (search:escape-unsupported-characters)
  * @see modules/query-guard.xqm (query-guard:check)
  * @see controller.xql (case 'search' -> local:serve-bad-request-page)
  */
 
-// Each value contains at least one rejected metacharacter.
-const maliciousQueries = [
-  'title:secret',     // : – Lucene field-scoping / injection
-  '../../etc/passwd', // / – path traversal
-  'boost^10',         // ^ – boost metacharacter
-  '[a TO z]',         // [ ] – range metacharacter
-  '{malformed}',      // { } – metacharacter
-  '100%'              // % – leftover / double percent-encoding
+// Previously rejected with 400; now escaped / passed through as literals -> 200.
+const literalQueries = [
+  'title:secret',     // : Lucene field syntax, now escaped
+  '../../etc/passwd', // / path-looking input, now escaped
+  'boost^10',         // ^ boost metacharacter, now escaped
+  '[a TO z]',         // [ ] range metacharacter, now escaped
+  '{malformed}',      // { } metacharacter, now escaped
+  '100%'              // % not a Lucene metachar; passes through literally
 ]
 
-describe('Search: malicious queries are rejected with 400', function () {
-  maliciousQueries.forEach(function (q) {
+describe('Search: unsupported characters are searched literally, not rejected', function () {
+  literalQueries.forEach(function (q) {
+    it(`responds 200 for q="${q}"`, function () {
+      cy.request({ url: 'search', qs: { q }, failOnStatusCode: false })
+        .its('status')
+        .should('eq', 200)
+    })
+  })
+})
+
+// SQL-injection probes: rejected with HTTP 400.
+const injectionQueries = [
+  // UNION-based probe. Original request:
+  //   GET /exist/apps/hsg-shell/search?q=gMxR%27%20UNION%20ALL%20SELECT%20NULL%2C...%2CNULL--%20-
+  "gMxR' UNION ALL SELECT NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL-- -",
+  '1 OR 1=1',            // boolean tautology
+  'x; DROP TABLE users'  // stacked statement
+]
+
+describe('Search: SQL-injection probes are rejected with 400', function () {
+  injectionQueries.forEach(function (q) {
     it(`responds 400 for q="${q}"`, function () {
       cy.request({ url: 'search', qs: { q }, failOnStatusCode: false })
         .its('status')
@@ -32,25 +54,13 @@ describe('Search: malicious queries are rejected with 400', function () {
   })
 
   it('renders the "Invalid search query" page for a rejected query', function () {
-    cy.visit('search', { qs: { q: 'title:secret' }, failOnStatusCode: false })
+    cy.visit('search', { qs: { q: '1 OR 1=1' }, failOnStatusCode: false })
     cy.get('h1').should('contain', 'Invalid search query')
-  })
-
-  // UNION-based SQL-injection probe. It contains no blacklisted characters
-  // (only ' , - and spaces once URL-decoded), so it is caught by the separate
-  // SQL-injection heuristic inside query-guard:check(), not the character check.
-  // Original request:
-  //   GET /exist/apps/hsg-shell/search?q=gMxR%27%20UNION%20ALL%20SELECT%20NULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL%2CNULL--%20-
-  it('responds 400 for a UNION-based SQL injection probe', function () {
-    const q = "gMxR' UNION ALL SELECT NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL-- -"
-    cy.request({ url: 'search', qs: { q }, failOnStatusCode: false })
-      .its('status')
-      .should('eq', 400)
   })
 })
 
 describe('Search: documented operators are still allowed', function () {
-  // Regression guard: legitimate Lucene syntax must NOT trigger the 400.
+  // Regression guard: legitimate Lucene syntax must NOT trigger a 400.
   it('responds 200 for a query using documented operators', function () {
     cy.request({
       url: 'search',


### PR DESCRIPTION
Harden the search `q` parameter against malformed and hostile input, with three distinct behaviours **by design**:

1. **Unsupported Lucene metacharacters → escaped (HTTP 200).** `! : ^ / \ [ ] { }` are backslash-escaped at query-build time in `search.xqm` (`search:escape-unsupported-characters`) so they are searched literally — yielding zero results — instead of breaking the Lucene parser or returning an error page. `%` and control characters are likewise harmless literals now.
2. **SQL-injection probes → rejected (HTTP 400).** The controller calls a single entry point, `query-guard:check()`, which serves `error-page-400.xml` when the query looks like a SQL-injection probe. The site has no SQL backend (searches run against Lucene), so a missed probe is inert — the patterns therefore bias hard toward *not* firing, to avoid ever 400-ing a legitimate history search.
3. **Oversized queries → rejected (HTTP 400).** `query-guard:check()` rejects a `q` whose total length exceeds `MAX-QUERY-LENGTH` (1000) *before* running the regex.

Documented Lucene operators (`" + - ( ) * ? ~` and AND/OR/NOT) pass through untouched throughout.

## SQL-injection heuristic

Case-insensitive signatures, each chosen to be effectively absent from ordinary prose:
- `union all select`, or `union select` followed by a SQL token (`null` / digit / `*` / `@` / `concat` / `distinct` / `from`) — not a plain word like "Committee"
- boolean tautology immediately after `or`/`and` (e.g. `OR 1=1`)
- `sleep(` / `benchmark(` / `pg_sleep(` with a numeric argument
- `waitfor delay`
- stacked statement after `;`
- the tell-tale `NULL,NULL` column-count padding (two comma-separated NULLs, so **Nullification** / **annulment** are safe)

**False-positive check:** 0 hits across a corpus of real history queries (incl. *European Union Select Committee*, *Nullification Crisis of 1832*, *Nixon -- Kissinger relations*, *fell asleep at Yalta*, *he said 1 = 1 in the memo*); 8/8 on known probes (sqlmap UNION, `OR 1=1`, `; DROP TABLE`, `OR sleep(5)`, `exec xp_cmdshell`, `benchmark(...)`).

## DoS considerations

The guard is hot code on unauthenticated input, ahead of the search. `fn:matches` over these patterns is **linear** — no catastrophic backtracking (ReDoS), confirmed by timing (1 KB → 2 ms … 32 KB → 63 ms, a straight line). The only lever was raw input *size* (a POST could carry ~200 KB → ~400 ms of CPU). The `MAX-QUERY-LENGTH` gate closes this: a 200 KB `q` now costs **~0.06 ms** and is rejected up front, which also shields the downstream Lucene parse / cache / render.

## Design notes

- **Escaping** lives in the search module (query-build time), not the controller; **rejection** (SQL-injection + length) lives in `query-guard` and is invoked once from the controller via `query-guard:check()`.
- eXist's `fn:matches` uses the W3C XPath regex grammar: no `\b` word-boundary escape (boundaries written as `(^|\W)` / `(\W|$)`).
- `query-guard:check()` accepts a sequence, so a repeated `q` parameter is handled (and its combined length is capped).

## Tests

- **xqsuite** (`test-query-guard.xqm`): SQL-injection detections, explicit false-positive guards (Union/Select adjacency, Nullification, annulment, `--` separator, `sleep(` in prose), the NULL-list rule, the length gate, and the `check()` entry point.
- **Cypress e2e** (`malicious-query.cy.js`): unsupported chars → 200 (escaped/literal), SQL-injection probes and over-length → 400, documented operators → 200.
