### PR TITLE
fix: restore TOC listings for publications without revisionDesc/@status

### DIFF
--- a/modules/frus-toc-html.xqm
+++ b/modules/frus-toc-html.xqm
@@ -54,10 +54,14 @@ declare function toc:prepare-sidebar-toc-list($nodes as node()*) {
 
 declare function toc:toc($model as map(*), $root as node()?, $show-heading as xs:boolean?, $highlight as xs:boolean?) {
     if ($root) then
-        let $some-published := root($root)//tei:revisionDesc[@status = ("published", "partially-published")]
+        (: FRUS volumes carry a tei:revisionDesc/@status and may be published in an anticipated
+           state, with TEI containing just chapter titles; suppress their TOC unless the volume
+           is at least partially published. Publications without a tei:revisionDesc/@status
+           (milestones, FAQ, HAC, short history, etc.) always show a TOC. :)
+        let $statuses := root($root)//tei:revisionDesc/@status
+        let $suppress := exists($statuses) and not($statuses = ("published", "partially-published"))
         return
-            (: only show a TOC if the volume is published or partially published :)
-            if ($some-published) then
+            if (not($suppress)) then
                 <div class="toc-inner">
                     { if ($show-heading) then <div><h2>{toc:volume-title($root, "volume")}</h2></div> else () }
                     <ul>

--- a/tests/cypress/e2e/ui-components/table-of-contents.cy.js
+++ b/tests/cypress/e2e/ui-components/table-of-contents.cy.js
@@ -1,0 +1,49 @@
+/**
+ * Table of contents listings (toc:table-of-contents)
+ *
+ * Regression tests for the sitewide TOC component shared by all publications.
+ * A change intended to suppress the TOC for anticipated (not-yet-published)
+ * FRUS volumes also suppressed it for every publication whose TEI carries no
+ * tei:revisionDesc/@status — Milestones, FAQ, HAC, and Short History — leaving
+ * their landing pages without any listing of articles/sections. These tests
+ * assert the listings are present, and that the FRUS suppression still works.
+ */
+
+describe('Table of contents listings', function () {
+  it('Milestones chapter page lists its articles', function () {
+    cy.visit('milestones/1750-1775')
+    cy.get('#content-inner .toc a.toc-link').should('have.length.at.least', 5)
+    cy.get('#content-inner .toc a.toc-link[href$="milestones/1750-1775/french-indian-war"]').should('exist')
+  })
+
+  it('FAQ page lists its sections', function () {
+    cy.visit('about/faq')
+    cy.get('#content-inner .toc a.toc-link').should('have.length.at.least', 5)
+    cy.get('#content-inner .toc a.toc-link[href$="about/faq/what-is-frus"]').should('exist')
+  })
+
+  it('HAC page lists its sections', function () {
+    cy.visit('about/hac')
+    cy.get('#content-inner .toc a.toc-link').should('have.length.at.least', 5)
+    cy.get('#content-inner .toc a.toc-link[href$="about/hac/members"]').should('exist')
+  })
+
+  it('Short History page lists its chapters', function () {
+    cy.visit('departmenthistory/short-history')
+    cy.get('#content-inner .toc a.toc-link').should('have.length.at.least', 5)
+    cy.get('#content-inner .toc a.toc-link[href$="departmenthistory/short-history/origins"]').should('exist')
+  })
+
+  it('Published FRUS volume landing page shows its table of contents', function () {
+    cy.visit('historicaldocuments/frus1947v03')
+    cy.get('.hsg-frus__toc a.toc-link').should('have.length.at.least', 5)
+    cy.get('.hsg-frus__toc a.toc-link[href$="historicaldocuments/frus1947v03/comp1"]').should('exist')
+  })
+
+  it('Anticipated (not yet published) FRUS volume landing page suppresses its table of contents', function () {
+    // frus1981-88v16 has revisionDesc/@status "being-cleared" as of 2026-07;
+    // if this volume is published, replace it with another anticipated volume
+    cy.visit('historicaldocuments/frus1981-88v16')
+    cy.get('a.toc-link').should('not.exist')
+  })
+})


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Problem

Reports came in today of missing content on production: the article listings on Milestones chapter pages (e.g. `/milestones/1750-1775`), the FAQ listing (`/about/faq`), the HAC listing (`/about/hac`), and the Short History chapter listing (`/departmenthistory/short-history`) all render an empty `<div class="toc"></div>` where the table of contents should be. The regression was invisible until now because the site's nginx caches had served year-old copies of these pages; repopulating the caches yesterday exposed it.

## Root cause

Commit 4e2e4c38 (2025-09-29, first released in v3.10.11) added a guard to `toc:toc()` in `modules/frus-toc-html.xqm` so that anticipated (not-yet-published) FRUS volumes — whose TEI may contain just chapter titles — don't display a table of contents:

```xquery
let $some-published := root($root)//tei:revisionDesc[@status = ("published", "partially-published")]
```

Every FRUS volume carries `tei:revisionDesc/@status`, so the guard behaves correctly there. But `toc:toc()` is shared by every publication that renders a TOC – including Milestones, FAQ, HAC, Short History, Buildings, Conferences, and FRUS History. These generally have no `tei:revisionDesc/@status` at all (nine Milestones chapters have a `revisionDesc` without `@status`; the rest have none). For all of those, the guard evaluated to false and the TOC was silently suppressed.

## Fix

Suppress the TOC only when the document actually carries `tei:revisionDesc/@status` and none of its values is `published` or `partially-published`. Documents without the attribute always show their TOC, restoring the pre-v3.10.11 behavior for non-FRUS publications while preserving the anticipated-volume suppression for FRUS.

Verified against a container built from `joewiz/hsg-project:latest`:

- `/milestones/1750-1775`, `/about/faq`, `/about/hac`, `/departmenthistory/short-history`, `/departmenthistory/buildings`, and `/conferences/2010-southeast-asia` all render their listings again
- published (`frus1937v04`) and partially published (`frus1969-76ve10`) volume landing pages still show their TOC
- an anticipated volume (`frus1981-88v16`, status `being-cleared`) still suppresses its TOC

## Tests

The existing Cypress specs for these pages only assert headlines, which is why the regression passed CI. This PR adds `tests/cypress/e2e/ui-components/table-of-contents.cy.js`, which asserts that the TOC listings contain links on all four reported page types and on a published FRUS volume landing page, and that an anticipated FRUS volume still suppresses its TOC. Run against the broken code, the four publication-listing tests fail and the two FRUS tests pass; against the fix, all six pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
