### PR TITLE
fix: suppress person list label, add term hanging

### DIFF
--- a/app/scss/_tei.scss
+++ b/app/scss/_tei.scss
@@ -47,19 +47,15 @@
 // (https://github.com/HistoryAtState/hsg-shell/issues/259)
 
 .list-person {
+  list-style-type: none;
   padding-left: 0;
 }
 
-#persons {
-  .tei-item .tei-item {
-    margin-left: 2em;
-    text-indent: -2em;
-  }
-}
+// Same hanging indents for the "sources" and "terms" glossary lists
 
-// Lists with hanging indents in "sources" - same as for "persons"
-
-#sources {
+#persons,
+#sources,
+#terms {
   .tei-item .tei-item {
     margin-left: 2em;
     text-indent: -2em;


### PR DESCRIPTION
## Suppress obscured list label in Persons

**Before:**

> <img width="599" height="344" alt="Screenshot 2026-08-05 at 22 53 19" src="https://github.com/user-attachments/assets/fa908ef6-6b20-4629-9eeb-dd4172f4eeda" />

**After:**

> <img width="622" height="346" alt="Screenshot 2026-08-06 at 10 51 18" src="https://github.com/user-attachments/assets/496c944e-0714-4200-a630-237397eea602" />

## Align Terms styling with Persons

**Before:**

> <img width="576" height="195" alt="Screenshot 2026-08-06 at 10 53 22" src="https://github.com/user-attachments/assets/35cd1964-5308-4ffe-9be2-ddbc30103857" />

**After:**

> <img width="571" height="190" alt="Screenshot 2026-08-06 at 10 53 34" src="https://github.com/user-attachments/assets/3128d0df-adf9-4599-bca6-8e73be7e5ead" />
