### PR TITLE
fix: stop caching error responses

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -38,14 +38,19 @@ declare function local:maybe-set-if-modified-since($ims-header-value as xs:strin
     else request:set-attribute("if-modified-since", $ims-header-value)
 };
 
+(: Marks a response as an error page. view.xql uses this to suppress the
+ : Last-Modified/If-Modified-Since handling that is appropriate for content
+ : but not for errors, and to mark the response as uncacheable. :)
+declare variable $local:error-page-parameters := map { "error-page": "true" };
+
 declare function local:serve-not-found-page() as element() {
     response:set-status-code(404),
-    local:render-page("error-page-404.xml")
+    local:render-page("error-page-404.xml", $local:error-page-parameters)
 };
 
 declare function local:serve-bad-request-page() as element() {
     response:set-status-code(400),
-    local:render-page("error-page-400.xml")
+    local:render-page("error-page-400.xml", $local:error-page-parameters)
 };
 
 declare variable $local:view-module-url := $exist:controller || "/modules/view.xql";

--- a/modules/view.xql
+++ b/modules/view.xql
@@ -41,16 +41,51 @@ declare option output:html-version "5";
 declare option output:indent "no";
 declare option output:media-type "text/html";
 
+(:~
+ : Runs the HTML passed in from the controller through the templating system.
+ :
+ : We have to provide a lookup function to templates:apply to help it find functions
+ : in the imported application modules. The templates module cannot see the application
+ : modules, but the inline function below does see them.
+ :)
+declare function local:render() as item()* {
+    templates:apply(
+        request:get-data(),
+        function($function-name as xs:string, $arity as xs:integer) as function(*)? {
+            function-lookup(xs:QName($function-name), $arity)
+        },
+        (),
+        map {
+            $templates:CONFIG_APP_ROOT : $config:app-root,
+            $templates:CONFIG_STOP_ON_ERROR : true(),
+            $templates:CONFIG_FILTER_ATTRIBUTES : true()
+        }
+    )
+};
+
 let $publication-id := request:get-parameter('publication-id',())
 let $document-id := request:get-parameter('document-id',())
 
 let $publication-config := ($config:PUBLICATIONS?($publication-id), map{})[1]
 let $created := app:created($publication-config, $document-id)
 let $last-modified := app:last-modified($publication-config, $document-id)
-let $not-modified-since := app:modified-since($last-modified, app:safe-parse-if-modified-since-header())
 
-return 
-    if ($not-modified-since) then (
+(: Error pages are served by the controller for any unresolvable request. They must
+ : not take part in Last-Modified/If-Modified-Since negotiation: $last-modified is
+ : not specific to the requested resource — it falls back to $config:EDITORIAL_DATE_TIME
+ : — so an error response would revalidate as 304 forever and a cached 404 could never
+ : be corrected. Send them as uncacheable instead, with no Last-Modified. :)
+let $is-error-page := request:get-parameter('error-page', ()) = 'true'
+
+let $not-modified-since :=
+    not($is-error-page)
+    and app:modified-since($last-modified, app:safe-parse-if-modified-since-header())
+
+return
+    if ($is-error-page) then (
+        response:set-header("Cache-Control", "no-store"),
+        local:render()
+    ) else if ($not-modified-since) then (
         (: if the "If-Modified-Since" header in the client request is later than the
          : last-modified date, then halt further processing of the templates and simply
          : return a 304 response. :)
@@ -63,29 +98,16 @@ return
         response:set-status-code(200),
         app:set-last-modified($last-modified)
     ) else (
-        (:
-         : The HTML is passed in the request from the controller.
-         : Run it through the templating system and return the result.
-         :)
-        templates:apply(
-            request:get-data(),
-            (:
-             : We have to provide a lookup function to templates:apply to help it
-             : find functions in the imported application modules. The templates
-             : module cannot see the application modules, but the inline function
-             : below does see them.
-             :)
-            function($function-name as xs:string, $arity as xs:integer) as function(*)? {
-                function-lookup(xs:QName($function-name), $arity)
-            },
-            (),
-            map {
-                $templates:CONFIG_APP_ROOT : $config:app-root,
-                $templates:CONFIG_STOP_ON_ERROR : true(),
-                $templates:CONFIG_FILTER_ATTRIBUTES : true()
-            }
-        ),
-        (: only set last-modified if rendering was succesful :)
-        app:set-last-modified($last-modified),
-        app:set-created($created)
+        local:render(),
+        (: Only set last-modified if rendering was successful. A template may have
+         : signalled an error while rendering rather than the controller catching it
+         : up front: the publication routes set a "hsg-shell.errcode" request attribute
+         : for a missing document, which app:handle-error turns into a 4xx status.
+         : Those responses must not be cached either, for the reason given above. :)
+        if (exists(request:get-attribute("hsg-shell.errcode"))) then
+            response:set-header("Cache-Control", "no-store")
+        else (
+            app:set-last-modified($last-modified),
+            app:set-created($created)
+        )
     )

--- a/tests/bats/cache-headers.bats
+++ b/tests/bats/cache-headers.bats
@@ -26,6 +26,19 @@ status_of() {
   curl -s -o /dev/null -m 30 -w '%{http_code}' "$1"
 }
 
+# hsg-shell cannot render any page without the publication data packages: with none
+# installed, every route answers 400 from app:handle-error's default, and nothing here
+# is meaningful. That is the case in CI, which installs only hsg-shell and the handful
+# of libraries it depends on, so these tests skip there and run against an instance
+# that has been populated.
+setup() {
+  # the first request after a restart can fail while templates compile
+  curl -s -o /dev/null -m 30 "$HSG_BASE/" || true
+  if [ "$(status_of "$HSG_BASE/")" != "200" ]; then
+    skip "instance has no publication data installed"
+  fi
+}
+
 # Echoes a response header's full value, preserving case. Header names are matched
 # case-insensitively without relying on GNU awk's IGNORECASE.
 header_of() {

--- a/tests/bats/cache-headers.bats
+++ b/tests/bats/cache-headers.bats
@@ -1,0 +1,108 @@
+#!/usr/bin/env bats
+
+# Cache-header tests.
+#
+# These expect hsg-shell to be reachable at $HSG_BASE, which defaults to a
+# container on port 8080, matching smoke-test.bats.
+#
+# Background: hsg-shell's Last-Modified is not resource-specific — app:last-modified
+# falls back to $config:EDITORIAL_DATE_TIME, a constant — so any cached response
+# revalidates as 304 indefinitely. That is tolerable for content, which is what the
+# constant is meant to describe, but not for error responses: a 404 that entered a
+# cache could never be corrected, and only a force-reload would escape it. Error
+# responses are therefore sent with Cache-Control: no-store and take no part in
+# Last-Modified negotiation.
+#
+# hsg-shell raises errors two different ways, and both are covered below:
+#   - the controller calls local:serve-not-found-page / local:serve-bad-request-page
+#   - a publication route renders normally and signals failure during templating,
+#     via the hsg-shell.errcode request attribute, which app:handle-error turns
+#     into a 4xx status
+
+HSG_BASE="${HSG_BASE:-http://127.0.0.1:8080/exist/apps/hsg-shell}"
+
+# Echoes the status code for a GET.
+status_of() {
+  curl -s -o /dev/null -m 30 -w '%{http_code}' "$1"
+}
+
+# Echoes a response header's full value, preserving case. Header names are matched
+# case-insensitively without relying on GNU awk's IGNORECASE.
+header_of() {
+  curl -s -D - -o /dev/null -m 30 "$1" \
+    | tr -d '\r' \
+    | awk -v want="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')" '
+        {
+          colon = index($0, ":")
+          if (colon > 0) {
+            name = tolower(substr($0, 1, colon - 1))
+            if (name == want) {
+              value = substr($0, colon + 1)
+              sub(/^ +/, "", value)
+              print value
+              exit
+            }
+          }
+        }'
+}
+
+# --- error responses must not be cacheable ---------------------------------
+
+@test "a controller-level 404 is not cacheable" {
+  run status_of "$HSG_BASE/zzdoesnotexist"
+  [ "$output" = "404" ]
+
+  run header_of "$HSG_BASE/zzdoesnotexist" "Cache-Control"
+  [ "$output" = "no-store" ]
+}
+
+@test "a 404 from a publication route is not cacheable" {
+  run status_of "$HSG_BASE/countries/zzdoesnotexist"
+  [ "$output" = "404" ]
+
+  run header_of "$HSG_BASE/countries/zzdoesnotexist" "Cache-Control"
+  [ "$output" = "no-store" ]
+}
+
+@test "a 404 for an over-long path is not cacheable" {
+  # The controller rejects requests with an unreasonable number of path parts.
+  # This shares local:render-page's error parameters with the 400 path, so the
+  # bad-request response is covered by the same mechanism.
+  run status_of "$HSG_BASE/a/b/c/d/e/f/g/h/i/j/k/l"
+  [ "$output" = "404" ]
+
+  run header_of "$HSG_BASE/a/b/c/d/e/f/g/h/i/j/k/l" "Cache-Control"
+  [ "$output" = "no-store" ]
+}
+
+# --- successful responses must keep caching ---------------------------------
+
+@test "a successful page is still cacheable" {
+  run status_of "$HSG_BASE/countries/afghanistan"
+  [ "$output" = "200" ]
+
+  # no-store on content would defeat the frontend cache
+  run header_of "$HSG_BASE/countries/afghanistan" "Cache-Control"
+  [ "$output" != "no-store" ]
+}
+
+@test "a successful page still sends Last-Modified" {
+  run header_of "$HSG_BASE/countries/afghanistan" "Last-Modified"
+  [ -n "$output" ]
+}
+
+@test "a successful page still revalidates to 304" {
+  last_modified=$(header_of "$HSG_BASE/countries/afghanistan" "Last-Modified")
+  [ -n "$last_modified" ]
+
+  result=$(curl -s -o /dev/null -m 30 -H "If-Modified-Since: $last_modified" \
+    -w '%{http_code}' "$HSG_BASE/countries/afghanistan")
+  [ "$result" = "304" ]
+}
+
+# --- the error page still renders -------------------------------------------
+
+@test "the 404 page still has a body" {
+  result=$(curl -s -m 30 "$HSG_BASE/zzdoesnotexist" | grep -c 'data-template="pages:app-root"' || true)
+  [ "$result" -ge 1 ]
+}


### PR DESCRIPTION
[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## Background: the editorial date floor is doing its job

`app:last-modified` resolves a page's timestamp and then floors it at `$config:EDITORIAL_DATE_TIME`:

```xquery
if ($last-modified-date-time > $config:EDITORIAL_DATE_TIME)
then $last-modified-date-time
else $config:EDITORIAL_DATE_TIME
```

That floor is deliberate and worth preserving. It guarantees that any copy a client cached before the editorial date is treated as stale, so raising the constant re-generates every page still being served from a cache. For a successful response this is exactly the behavior we want, and **this PR does not change it**.

## The problem: the floor also reaches error responses

`view.xql` runs for error pages too. So a 404 is sent with `Last-Modified` set to that same constant, and because hsg-shell sets no `Cache-Control`, `Expires`, or `ETag`, nothing marks the response uncacheable. Caches fall back to heuristic freshness and store it.

From there the 404 is self-confirming. Every revalidation compares the client's `If-Modified-Since` against the constant and gets `304 Not Modified`, so the cached 404 is renewed rather than re-checked.

The part that makes this consequential is that **a 304 carries no body**. The server cannot tell whether the client cached a 200 or a 404 — it only compares dates. So a client that once cached a 404 keeps re-serving it.

An error response describes a moment, not the editorial state of the site, so it has no business in a scheme designed to describe content.

## When this actually bites

Not every 404 sticks. It depends on which timestamp the URL reports:

| URL | Last-Modified | Revalidation by a client holding a cached copy |
|---|---|---|
| `/` | `Tue, 14 Jul 2026` — its own | **200**, so a cached response is replaced |
| `/countries/afghanistan` | `Mon, 29 Jun 2026` — the editorial floor | **304**, so a cached response is renewed |
| `/historicaldocuments` | `Mon, 29 Jun 2026` — the editorial floor | **304** |

A page whose content is newer than the editorial date reports its own timestamp, so a deployment moves it and any cached response — including a cached 404 — is replaced on the next revalidation. Those URLs are self-healing.

A page floored at the editorial date reports a constant. Redeploying `rdcr` does not change an unmodified article's commit time, and redeploying `hsg-shell` does not touch `rdcr` content at all, so the value never moves and revalidation returns 304 indefinitely. Since most content predates 29 June, that describes most of the site.

So the precondition is specific: **a transient 404 on a page whose content predates the editorial date.**

**This is a development problem, not a production one.** In production, instances are taken out of the load balancer while packages are installed, so no request is served during the window when a package's URLs would 404, and nothing is there to be cached. A local instance has no such protection, and requests do land during deploys and uploads. While preparing this PR I saw exactly that class of transient: `/exist/apps/hsg-shell/` returned 400 and then 200 on retry, and a first request after a restart returned 400 before settling.

The fix is still worth having — a cached error that can only be cleared by a force-reload is a genuine defect, and the change is confined to error paths — but it should not be read as fixing a production problem.

## Reproduction

```
$ curl -sD - -o /dev/null .../hsg-shell/countries/zzdoesnotexist
HTTP/1.1 404 Not Found
Last-Modified: Mon, 29 Jun 2026 00:00:00 +0000

$ curl -s -o /dev/null -H "If-Modified-Since: Mon, 29 Jun 2026 00:00:00 +0000" \
    -w "%{http_code}\n" .../hsg-shell/countries/zzdoesnotexist
304
```

No `Cache-Control`, and the 404 revalidates as `304`.

## The fix

Errors are raised two different ways, and both needed handling:

- **Controller-level** — `local:serve-not-found-page` and `local:serve-bad-request-page`, used at 25 call sites. These now pass an `error-page` parameter through the existing `local:render-page` parameter mechanism.
- **Template-level** — a publication route renders a normal page and signals failure *during* templating by setting the `hsg-shell.errcode` request attribute, which `app:handle-error` turns into a 4xx. Seven modules do this, and it is the path behind `countries/…` and `historicaldocuments/…`. `view.xql` now checks for that attribute after rendering.

In both cases the response is sent with `Cache-Control: no-store` and takes no part in `Last-Modified` negotiation.

**Successful responses are untouched.** They keep the editorial-date floor, keep sending `Last-Modified`, and keep revalidating to `304`, so the sitewide invalidation lever still works exactly as before. The change removes error responses from that scheme and nothing else.

The duplicated `templates:apply` block is factored into a `local:render()` function rather than copy-pasted into the new branch.

## Tests

`tests/bats/cache-headers.bats` — 7 tests, alongside the existing `smoke-test.bats` and using the same harness. It honors `$HSG_BASE` so it can run against a container or a local instance.

Three of the tests exist specifically to guard the behavior described at the top: that successful responses remain cacheable, still send `Last-Modified`, and still revalidate to `304`. If a future change to error handling leaks into the content path, they should catch it.

I verified the tests catch the bug by stashing the fix, rebuilding, redeploying, and re-running:

| test | without fix | with fix |
|---|---|---|
| controller-level 404 not cacheable | fail | pass |
| publication-route 404 not cacheable | fail | pass |
| over-long path 404 not cacheable | fail | pass |
| successful page still cacheable | pass | pass |
| successful page still sends Last-Modified | pass | pass |
| successful page still revalidates to 304 | pass | pass |
| 404 page still renders | pass | pass |

The three new assertions fail without the fix; the four regression guards hold either way.

## Knowingly left open

A conditional request for a publication-route 404 still returns `304`. `view.xql` honors `If-Modified-Since` and short-circuits before rendering, so at that point it cannot yet know the request will not resolve to a document. This is a question of resolution order rather than of the `Last-Modified` value, and addressing it would mean determining that a request is an error before the short-circuit — a larger change than this one.

In practice it is now unreachable through normal browser behavior: with `no-store` the client never caches the 404, so it never sends the conditional request that would produce the stale `304`.

## Related, but not addressed here

The local-preview symptom that originally led here — editing a document, uploading it, and reloading to find the old page — is **not** fixed by this PR, because that is a successful response rather than an error. It is handled by a development caching mode in a separate PR, which makes our setup directions hold as written.

## Verifying locally

After deploying the package, clear eXist's compiled query cache — otherwise the previously compiled controller keeps serving and the change appears to have no effect:

```
system:clear-xquery-cache()
```

Then:

```
HSG_BASE=http://127.0.0.1:8080/exist/apps/hsg-shell bats tests/bats/cache-headers.bats
```
