### PR TITLE
feat: add a development HTTP caching mode

### DIFF
--- a/modules/config.xqm
+++ b/modules/config.xqm
@@ -28,6 +28,27 @@ declare namespace xhtml="http://www.w3.org/1999/xhtml";
  : this date :)
 declare variable $config:EDITORIAL_DATE_TIME := xs:dateTime("2026-06-29T00:00:00-00:00");
 
+(: Whether hsg-shell participates in HTTP caching: whether it sends Last-Modified and
+ : honors a client's If-Modified-Since.
+ :
+ : This is unrelated to the server-side caches built on eXist's cache: module, such as
+ : "hsg-search" in search.xqm and "last-modified" in sitemap-config.xqm. Those cache data
+ : inside the database; this governs what we tell a client about the freshness of a
+ : response.
+ :
+ : Set the Java system property hsg.http.caching to "off" to disable it, for example with
+ : -Dhsg.http.caching=off in JAVA_OPTS, or via JAVA_TOOL_OPTIONS in a container. Local and
+ : containerized development instances should run with it off, so that a document uploaded
+ : for preview is visible on the next reload instead of after a force-reload:
+ : $config:EDITORIAL_DATE_TIME describes the editorial state of the site rather than the
+ : mtime of any one document, so an upload does not move it and a warm cache would
+ : otherwise keep serving the previous rendering.
+ :
+ : Only the exact value "off" disables it. An unset property, or a typo, leaves HTTP
+ : caching enabled, so production cannot lose it by accident. :)
+declare variable $config:HTTP_CACHING_ENABLED as xs:boolean :=
+    not(util:system-property("hsg.http.caching") = "off");
+
 (:
     Determine the application root collection from the current module load path.
 :)

--- a/modules/view.xql
+++ b/modules/view.xql
@@ -47,7 +47,13 @@ let $document-id := request:get-parameter('document-id',())
 let $publication-config := ($config:PUBLICATIONS?($publication-id), map{})[1]
 let $created := app:created($publication-config, $document-id)
 let $last-modified := app:last-modified($publication-config, $document-id)
-let $not-modified-since := app:modified-since($last-modified, app:safe-parse-if-modified-since-header())
+
+(: With HTTP caching off (see $config:HTTP_CACHING_ENABLED) the response takes no part in
+ : Last-Modified negotiation at all: neither short-circuit below may fire, since both
+ : exist only to serve a cache revalidating what it already holds. :)
+let $not-modified-since :=
+    $config:HTTP_CACHING_ENABLED
+    and app:modified-since($last-modified, app:safe-parse-if-modified-since-header())
 
 return 
     if ($not-modified-since) then (
@@ -56,7 +62,7 @@ return
          : return a 304 response. :)
         response:set-status-code(304),
         app:set-last-modified($last-modified)
-    ) else if (request:get-parameter('x-method', ()) eq 'head') then (
+    ) else if ($config:HTTP_CACHING_ENABLED and request:get-parameter('x-method', ()) eq 'head') then (
         (: When revalidating a cached resource and the "If-Modified-Since" header sent by the client indicates
          : the resource has changed in the meantime, it is just a head request. Do not render the page as the 
          : response body is discarded anyway and just return status code 200. :)
@@ -86,6 +92,12 @@ return
             }
         ),
         (: only set last-modified if rendering was succesful :)
-        app:set-last-modified($last-modified),
-        app:set-created($created)
+        if ($config:HTTP_CACHING_ENABLED) then (
+            app:set-last-modified($last-modified),
+            app:set-created($created)
+        ) else (
+            (: no Last-Modified at all, so nothing can revalidate against a value that
+             : does not track the document that was just uploaded :)
+            response:set-header("Cache-Control", "no-store")
+        )
     )

--- a/tests/bats/caching-mode.bats
+++ b/tests/bats/caching-mode.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+
+# Tests for the development caching mode ($config:HTTP_CACHING_ENABLED).
+#
+# hsg-shell describes a page's freshness by $config:EDITORIAL_DATE_TIME, the editorial
+# state of the site, rather than by the mtime of any one document. That is deliberate,
+# and correct in production, where content arrives by deployment. It is awkward during
+# local preview: uploading a document does not move the date, so a client holding a
+# cached copy is told nothing changed and keeps showing the previous rendering until a
+# force-reload.
+#
+# Setting the Java system property hsg.http.caching to "off" disables caching for exactly that
+# case. Which of the two suites below applies depends on how the instance was started,
+# so each skips when it does not.
+#
+#   caching on  (default):   bats tests/bats/caching-mode.bats
+#   caching off:             start eXist with JAVA_OPTS=-Dhsg.http.caching=off, then re-run
+
+HSG_BASE="${HSG_BASE:-http://127.0.0.1:8080/exist/apps/hsg-shell}"
+PAGE="$HSG_BASE/countries/afghanistan"
+
+header_of() {
+  curl -s -D - -o /dev/null -m 30 "$1" \
+    | tr -d '\r' \
+    | awk -v want="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')" '
+        {
+          colon = index($0, ":")
+          if (colon > 0) {
+            name = tolower(substr($0, 1, colon - 1))
+            if (name == want) {
+              value = substr($0, colon + 1)
+              sub(/^ +/, "", value)
+              print value
+              exit
+            }
+          }
+        }'
+}
+
+# "off" when the instance was started with -Dhsg.http.caching=off, else "on"
+caching_mode() {
+  if [ "$(header_of "$PAGE" 'Cache-Control')" = "no-store" ]; then echo off; else echo on; fi
+}
+
+setup() {
+  # warm the instance: the first request after a restart can fail while templates compile
+  curl -s -o /dev/null -m 30 "$PAGE" || true
+
+  # hsg-shell cannot render any page without the publication data packages: with none
+  # installed every route answers 400, and the mode cannot be detected from the headers.
+  # That is the case in CI, which installs only hsg-shell and its libraries.
+  if [ "$(curl -s -o /dev/null -m 30 -w '%{http_code}' "$HSG_BASE/")" != "200" ]; then
+    skip "instance has no publication data installed"
+  fi
+}
+
+# --- caching enabled (production default) -----------------------------------
+
+@test "with caching on, a page sends Last-Modified" {
+  [ "$(caching_mode)" = "on" ] || skip "instance started with hsg.http.caching=off"
+  run header_of "$PAGE" 'Last-Modified'
+  [ -n "$output" ]
+}
+
+@test "with caching on, a page revalidates to 304" {
+  [ "$(caching_mode)" = "on" ] || skip "instance started with hsg.http.caching=off"
+  last_modified=$(header_of "$PAGE" 'Last-Modified')
+  [ -n "$last_modified" ]
+  result=$(curl -s -o /dev/null -m 30 -H "If-Modified-Since: $last_modified" -w '%{http_code}' "$PAGE")
+  [ "$result" = "304" ]
+}
+
+@test "with caching on, a page is not marked no-store" {
+  [ "$(caching_mode)" = "on" ] || skip "instance started with hsg.http.caching=off"
+  run header_of "$PAGE" 'Cache-Control'
+  [ "$output" != "no-store" ]
+}
+
+# --- caching disabled (development) -----------------------------------------
+
+@test "with caching off, a page is marked no-store" {
+  [ "$(caching_mode)" = "off" ] || skip "instance started with caching enabled"
+  run header_of "$PAGE" 'Cache-Control'
+  [ "$output" = "no-store" ]
+}
+
+@test "with caching off, a conditional request is not answered with 304" {
+  # This is what makes an uploaded edit visible on an ordinary reload: the client's
+  # If-Modified-Since can no longer match a date that does not track the document.
+  [ "$(caching_mode)" = "off" ] || skip "instance started with caching enabled"
+  result=$(curl -s -o /dev/null -m 30 \
+    -H "If-Modified-Since: Mon, 29 Jun 2026 00:00:00 +0000" -w '%{http_code}' "$PAGE")
+  [ "$result" = "200" ]
+}
+
+@test "with caching off, a page still renders" {
+  [ "$(caching_mode)" = "off" ] || skip "instance started with caching enabled"
+  result=$(curl -s -m 30 "$PAGE" | grep -c 'data-template="pages:app-root"' || true)
+  [ "$result" -ge 1 ]
+}


### PR DESCRIPTION

[This PR was prompted by Joe, drafted by Claude Code, and reviewed by Joe.]

## The problem

hsg-shell describes a page's freshness by `$config:EDITORIAL_DATE_TIME` — the editorial state of the site — rather than by the mtime of any one document. That is deliberate, and right in production, where content arrives by deployment and raising the constant re-generates every page still being served from a cache.

It is awkward during local preview. Uploading a document does not move the editorial date, so a client holding a cached copy is told nothing changed and keeps showing the previous rendering.

This is not hypothetical: our setup directions walk a new user through editing `rdcr/articles/afghanistan.xml`, uploading it with `Upload current file to localhost`, and reloading to see the change. That instruction does not currently hold. Reproduced against a local instance before this change:

| step | result |
|---|---|
| view the page (browser caches it) | `Last-Modified: Mon, 29 Jun 2026 00:00:00 +0000` |
| edit the article and upload it | succeeds — the new content *is* in the database |
| reload (a conditional request, as a browser sends) | **304 — the old page** |
| force-reload | 200, edit visible |

## The change

Setting the Java system property `hsg.http.caching` to `off` disables HTTP caching. The response then carries `Cache-Control: no-store`, sends no `Last-Modified`, and takes no part in conditional-request handling — neither short-circuit in `view.xql` fires, since both exist only to serve a cache revalidating what it already holds.

After the change, the same walkthrough returns **200 with the edit visible**, on an ordinary reload.

Three decisions worth flagging for review:

- **Only the exact value `off` disables caching.** An unset property, or a typo, leaves caching enabled. Production needs no configuration to keep behaving exactly as it does today, and cannot lose caching by accident.
- **`Last-Modified` is suppressed rather than sent alongside `no-store`.** Sending both is contradictory, and suppressing it guarantees no conditional request can be honored.
- **The `x-method: head` short-circuit is disabled too**, for the same reason as the `If-Modified-Since` one.

## On the name

The property and `$config:HTTP_CACHING_ENABLED` are named for HTTP deliberately. They have nothing to do with the server-side caches built on eXist's `cache:` module — `"hsg-search"` in `search.xqm`, and `"last-modified"` in `sitemap-config.xqm`, whose name is especially easy to mistake for the header this governs. Those cache data inside the database; this governs what we tell a client about the freshness of a response.

## How it is set

`startup.sh` honors `$JAVA_OPTS`:

```bash
JAVA_OPTS=-Dhsg.http.caching=off /path/to/eXist-db.app/Contents/Resources/bin/startup.sh
```

A container can pass it through `JAVA_TOOL_OPTIONS`, which is how the hsg-project image already supplies its JVM options. A sensible follow-up is to set it there, so a development instance is correct out of the box.

## Tests

`tests/bats/caching-mode.bats` — two mutually exclusive suites, each skipping when the instance was not started for it, so the file is meaningful either way. I verified both by restarting eXist each way:

| | caching on (default) | caching off |
|---|---|---|
| sends `Last-Modified` | pass | skip |
| revalidates to 304 | pass | skip |
| not marked `no-store` | pass | skip |
| marked `no-store` | skip | pass |
| conditional request not answered with 304 | skip | pass |
| page still renders | skip | pass |

The suite also skips entirely when the instance has no publication data installed, since hsg-shell cannot render a page without it and every route answers 400. That is the case in the GitHub workflow, which installs only hsg-shell and the libraries it depends on.

## Notes for review

eXist emits a `Last-Modified` of its own on these responses. It is inert, since `no-store` prevents the response being stored at all.

This is independent of #624, which stops error responses being cached. The two touch `view.xql` in nearby places and will conflict slightly; #624 is the smaller change and is further along, so merging it first and rebasing this one is probably easiest.
