### PR TITLE
fix(controller): return 404 for direct requests to XQuery modules

### DIFF
--- a/controller.xql
+++ b/controller.xql
@@ -124,12 +124,6 @@ else if (ends-with($exist:path, "validate-results-of-twitter-jobs.xq")) then
         </error-handler>
     </dispatch>
 
-(: ignore direct requests to main modules :)
-else if (ends-with($exist:resource, ".xql")) then
-    <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
-        <ignore/>
-    </dispatch>
-
 else if (starts-with($exist:path, "/sitemap")) then
      <dispatch xmlns="http://exist.sourceforge.net/NS/exist">
          <forward url="{$exist:controller || "/resources/sitemaps" || $exist:path}"/>

--- a/tests/cypress/e2e/security/direct-module-access.cy.js
+++ b/tests/cypress/e2e/security/direct-module-access.cy.js
@@ -1,0 +1,87 @@
+/**
+ * Direct HTTP access to XQuery modules must be refused with a 404.
+ *
+ * The controller used to answer requests for `*.xql` with `<ignore/>`, which
+ * hands the request straight to eXist-db. eXist then tries to execute the
+ * module, and the resulting XQuery error page leaks internal details
+ * (module paths, function names, stack traces). That branch is gone: `*.xql`
+ * requests now fall through to the controller's final `default` and get the
+ * site's own 404 page.
+ *
+ * Library modules (`*.xqm`) and test scripts (`*.xq`) never matched the
+ * `<ignore/>` branch and always took that same path. They are covered here as
+ * a regression guard.
+ *
+ * @see controller.xql (fallback `default return local:serve-not-found-page()`)
+ * @see tests/cypress/e2e/error/404.cy.js
+ */
+
+const NOT_FOUND_TITLE = 'Page not found - Office of the Historian'
+
+// Markers that only appear when eXist renders an XQuery error itself.
+const XQUERY_ERROR_MARKERS = [
+  'XPathException',
+  'exerr:',
+  'err:XPST',
+  'err:XPDY',
+  'err:XPTY',
+  'XQuery error'
+]
+
+function expectSiteNotFound (path) {
+  cy.request({ url: path, failOnStatusCode: false }).then(function (res) {
+    expect(res.status, `status for ${path}`).to.eq(404)
+    expect(res.body, `body for ${path}`).to.include(NOT_FOUND_TITLE)
+    XQUERY_ERROR_MARKERS.forEach(function (marker) {
+      expect(res.body, `body for ${path} must not contain "${marker}"`).not.to.include(marker)
+    })
+  })
+}
+
+// Main modules: executable if eXist gets to see the request.
+const mainModules = [
+  'modules/view.xql',
+  'modules/frus-ajax.xql',
+  'modules/open.xql',
+  'modules/opds-catalog.xql',
+  'modules/volume-ids.xql',
+  'modules/volume-images.xql',
+  'modules/does-not-exist.xql'
+]
+
+describe('Security: direct requests to main modules (*.xql) return the site 404 page', function () {
+  mainModules.forEach(function (path) {
+    it(`responds 404 without an XQuery error for ${path}`, function () {
+      expectSiteNotFound(path)
+    })
+  })
+
+  it('responds 404 for a main module requested with query parameters', function () {
+    expectSiteNotFound('modules/view.xql?publication-id=app')
+  })
+
+  it('responds 404 for the controller itself', function () {
+    expectSiteNotFound('controller.xql')
+  })
+
+  it('renders the "Page not found" page in the browser', function () {
+    cy.visit('modules/view.xql', { failOnStatusCode: false })
+    cy.title().should('include', NOT_FOUND_TITLE)
+  })
+})
+
+// Library modules and test scripts: never routed, must stay 404.
+const otherModules = [
+  'modules/app.xqm',
+  'modules/query-guard.xqm',
+  'modules/search.xqm',
+  'tests/xquery/validate-replication.xq'
+]
+
+describe('Security: direct requests to library modules and scripts return the site 404 page', function () {
+  otherModules.forEach(function (path) {
+    it(`responds 404 without an XQuery error for ${path}`, function () {
+      expectSiteNotFound(path)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Direct requests to main modules such as `/exist/apps/hsg-shell/modules/view.xql` used to hit an `<ignore/>` branch in `controller.xql`. That handed the request to eXist-db, which tried to execute the module and answered with an XQuery error page exposing internal details (module paths, function names, stack traces).

This PR removes that branch. `*.xql` requests now fall through to the controller's fallback and get the site's own 404 page, which is how `*.xqm` and `*.xq` requests were already handled.

## Test

New Cypress spec `tests/cypress/e2e/security/direct-module-access.cy.js`, picked up automatically by the existing Cypress workflow. It requests six real main modules, a nonexistent `.xql`, a `.xql` with query parameters, the controller itself, three `.xqm` library modules and a `.xq` test script, and asserts for each:

- HTTP 404
- the body is the site's "Page not found" page
- the body contains no XQuery error markers (`XPathException`, `err:XPST`, ...)

Verified against a local `joewiz/hsg-project` container:

| Controller | Result |
|---|---|
| this branch | 14 passing |
| master | 10 failing (all `.xql` cases: HTTP 400 with XQuery error, or eXist's raw Jetty 404 exposing the `/db/apps/...` path), 4 passing |

## Notes

- The only client-side reference to a module URL, the `frus-ajax.xql` call in `resources/scripts/app.js`, sits inside a block that has been commented out, so nothing in the frontend depends on the old behaviour.
- `urls.xml` still documents the `.xql$` path as `<ignore/>`; left untouched here.

🤖 PR was generated with [Claude Code](https://claude.com/claude-code) fix was created by Juri Leino
